### PR TITLE
Update docs test examples

### DIFF
--- a/docs/source/customizing-container.rst
+++ b/docs/source/customizing-container.rst
@@ -2,7 +2,7 @@
 Customizing a mango container
 ========
 
-A mango container can be customized regarding its way it connects to other container (
+A mango container can be customized regarding its way it connects to other containers.
 
 ***************
 connection type

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -49,8 +49,12 @@ Linting
 
 Another approach to improve the code quality is static code analysis, or better known as linting. Linting is an easy to set up possibility to make sure that a certain code standard is fulfilled. There are many useful rules, which can be checked automatically, so we have another line of defense and spare some time when reviewing. 
 
-
 Formatting
 *****************
 
 The project is formatted using black + isort with default settings.
+
+```bash
+isort mango examples tests
+black mango examples tests
+```

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -111,7 +111,7 @@ to another agent:
                     content="Hello world!")
                 )
 
-            def handle_messafe(self, content, meta):
+            def handle_message(self, content, meta):
                 print(f"Received a message with the following content: {content}")
 
 We are using the scheduling API, which is explained in further detail in the section :doc:`scheduling`.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,16 +21,19 @@ Once you have created a virtual environment you can just run pip__ to install it
 __ https://pip.pypa.io/en/stable/
 
 ..
-    Installation from source
-    -----------------------
-    **TODO write this section**
+Installation from source
+-----------------------
+To install from source, simply check out this repository and install in editable mode using pip:
 
+.. code-block:: console
+
+    $ pip install -e .
 
 Using a local message broker
 -----------------------
 If you want to make use of the functional mqtt modules to modularize your agent,
 you must have a local message broker running on your system.
-We recommend Mosquitto__. On Ubuntu it can be installed as follows:
+We recommend Mosquitto__. On Debian/Ubuntu it can be installed as follows:
 
 .. code-block:: console
 

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -18,6 +18,8 @@ The core of this API is the scheduler, which is part of every agent. To schedule
      - Executes the coroutine at a specified datetime
    * - PeriodicScheduledTask
      - Executes a coroutine periodically with a static delay between the cycles
+   * - RecurrentScheduledTask
+     - Executes a coroutine according to a dynamic repetition scheme provided by a `rrule`
    * - ConditionalScheduledTask
      - Executes the coroutine when a specified condition evaluates to True
    * - AwaitingTask
@@ -92,13 +94,13 @@ In mango the following process tasks are available:
 
         class ScheduleAgent(Agent):
             def __init__(self, container, other_addr, other_id):
-                self.schedule_instant_process_task(coroutine_creator=lambda: self.context.send_acl_message(
+                self.schedule_instant_process_task(coroutine_creator=lambda: self.send_acl_message(
                     receiver_addr=other_addr,
                     receiver_id=other_id,
                     content="Hello world!")
                 )
                 # equivalent to
-                self.schedule_process_task(InstantScheduledProcessTask(coroutine_creator=lambda: self.context.send_acl_message(
+                self.schedule_process_task(InstantScheduledProcessTask(coroutine_creator=lambda: self.send_acl_message(
                     receiver_addr=other_addr,
                     receiver_id=other_id,
                     content="Hello world!"))
@@ -135,7 +137,7 @@ control how fast or slow time passes within your agent system:
                                          timestamp=self.current_timestamp + 5)
 
         async def send_hello_world(self, receiver_addr, receiver_id):
-            await self.context.send_acl_message(receiver_addr=receiver_addr,
+            await self.send_acl_message(receiver_addr=receiver_addr,
                                                receiver_id=receiver_id,
                                                content='Hello World')
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -240,12 +240,12 @@ Second, we set ``acl_meta`` to contain the typing information of our message.
             reported_feed_in = PV_FEED_IN[self.aid]  # PV_FEED_IN must be defined at the top
             content = reported_feed_in
 
-            acl_meta = {"sender_addr": self.context.addr, "sender_id": self.aid,
+            acl_meta = {"sender_addr": self.addr, "sender_id": self.aid,
                         "performative": Performatives.inform}
 
             # Note, could be shortened using self.schedule_instant_acl_message
             self.schedule_instant_task(
-                self.context.send_acl_message(
+                self.send_acl_message(
                     content=content,
                     receiver_addr=sender_addr,
                     receiver_id=sender_id,
@@ -257,7 +257,7 @@ Second, we set ``acl_meta`` to contain the typing information of our message.
             self.max_feed_in = float(max_feed_in)
             print(f"{self.aid}: Limiting my feed_in to {max_feed_in}")
             self.schedule_instant_task(
-                self.context.send_acl_message(
+                self.send_acl_message(
                     content=None,
                     receiver_addr=sender_addr,
                     receiver_id=sender_id,
@@ -292,11 +292,11 @@ perform its active actions. We do this by implementing a ``run`` function with t
             # ask pv agent feed-ins
             for addr, aid in self.known_agents:
                 content = None
-                acl_meta = {"sender_addr": self.context.addr, "sender_id": self.aid,
+                acl_meta = {"sender_addr": self.addr, "sender_id": self.aid,
                             "performative": Performatives.request}
                 # alternatively we could call send_acl_message here directly and await it
                 self.schedule_instant_task(
-                    self.context.send_acl_message(
+                    self.send_acl_message(
                         content=content,
                         receiver_addr=addr,
                         receiver_id=aid,
@@ -313,12 +313,12 @@ perform its active actions. We do this by implementing a ``run`` function with t
 
             for addr, aid in self.known_agents:
                 content = min_feed_in
-                acl_meta = {"sender_addr": self.context.addr, "sender_id": self.aid,
+                acl_meta = {"sender_addr": self.addr, "sender_id": self.aid,
                             "performative": Performatives.propose}
 
                 # alternatively we could call send_acl_message here directly and await it
                 self.schedule_instant_task(
-                    self.context.send_acl_message(
+                    self.send_acl_message(
                         content=content,
                         receiver_addr=addr,
                         receiver_id=aid,

--- a/examples/ping_pong_termination.py
+++ b/examples/ping_pong_termination.py
@@ -10,7 +10,7 @@ class Caller(Agent):
         super().__init__(container)
         self.schedule_timestamp_task(
             coroutine=self.send_hello_world(receiver_addr, receiver_id),
-            timestamp=self._context.current_timestamp + 5,
+            timestamp=self.current_timestamp + 5,
         )
         self.i = 0
 
@@ -24,7 +24,7 @@ class Caller(Agent):
         self.i += 1
         if self.i < 100:
             self.schedule_instant_acl_message(
-                receiver_addr=self._context.addr, receiver_id="agent0", content=self.i
+                receiver_addr=self.addr, receiver_id="agent0", content=self.i
             )
 
 
@@ -35,7 +35,7 @@ class Receiver(Agent):
     def handle_message(self, content, meta):
         print(f"{self.aid} Received a message with the following content {content}.")
         self.schedule_instant_acl_message(
-            receiver_addr=self._context.addr, receiver_id="agent1", content=content
+            receiver_addr=self.addr, receiver_id="agent1", content=content
         )
 
 

--- a/examples/simple_agent.py
+++ b/examples/simple_agent.py
@@ -33,7 +33,7 @@ class SimpleAgent(Agent):
                 message_content = other_proto_msg.GenericMsg()
                 message_content.text = "Hi there"
             acl_meta = {
-                "reply_by": "greeting",
+                "reply_with": "greeting",
                 "conversation_id": f"{self.aid}_1",
                 "performative": Performatives.inform.value,
                 "sender_id": self.aid,
@@ -59,10 +59,10 @@ class SimpleAgent(Agent):
 
     async def react_to_greeting(self, msg_in, meta_in):
         conversation_id = meta_in["conversation_id"]
-        reply_by = meta_in["reply_by"]
+        reply_with = meta_in["reply_with"]
         sender_id = meta_in["sender_id"]
         sender_addr = meta_in["sender_addr"]
-        if not reply_by:
+        if not reply_with:
             # No reply necessary - remove conversation id
             if conversation_id in self.conversations:
                 self.conversations.remove(conversation_id)
@@ -70,18 +70,18 @@ class SimpleAgent(Agent):
             # prepare a reply
             if conversation_id not in self.conversations:
                 self.conversations.append(conversation_id)
-            if reply_by == "greeting":
+            if reply_with == "greeting":
                 # greet back
                 message_out_content = "Hi there too"
                 reply_key = "greeting2"
-            elif reply_by == "greeting2":
+            elif reply_with == "greeting2":
                 # back greeting received, send good bye
                 message_out_content = "Good Bye"
                 # end conversation
                 reply_key = None
                 self.conversations.remove(conversation_id)
             else:
-                assert False, f"got strange reply_by: {reply_by}"
+                assert False, f"got strange reply_with: {reply_with}"
             if self.codec == "json":
                 message = ACLMessage_json(
                     sender_id=self.aid,
@@ -89,8 +89,8 @@ class SimpleAgent(Agent):
                     receiver_id=sender_id,
                     receiver_addr=sender_addr,
                     content=message_out_content,
-                    in_reply_to=reply_by,
-                    reply_by=reply_key,
+                    in_reply_to=reply_with,
+                    reply_with=reply_key,
                     conversation_id=conversation_id,
                     performative=Performatives.inform,
                 )
@@ -99,9 +99,9 @@ class SimpleAgent(Agent):
                 message.sender_id = self.aid
                 message.sender_addr = self.addr_str
                 message.receiver_id = sender_id
-                message.in_reply_to = reply_by
+                message.in_reply_to = reply_with
                 if reply_key:
-                    message.reply_by = reply_key
+                    message.reply_with = reply_key
                 message.conversation_id = conversation_id
                 message.performative = Performatives.inform.value
                 sub_msg = other_proto_msg.GenericMsg()

--- a/examples/tcp_container_example.py
+++ b/examples/tcp_container_example.py
@@ -8,7 +8,9 @@ from mango import create_container
 async def one_container_two_agents():
     # ip and port of container
     addr1 = ("127.0.0.1", 5555)
-    codec = "json"
+    from mango.messages.codecs import JSON
+
+    codec = JSON()
     container1 = await create_container(connection_type="tcp", codec=codec, addr=addr1)
     agent_a = SimpleAgent(container1, codec=codec)
 
@@ -32,9 +34,6 @@ async def one_container_two_agents():
 def two_container_two_agents():
     addr1 = (("127.0.0.1", 5555),)
     addr2 = (("127.0.0.1", 5555),)
-    codec = ("protobuf",)
-    proto_msgs_module = other_proto_msg
-    pass
 
 
 if __name__ == "__main__":

--- a/examples/tutorial/v2_inter_container_messaging_and_basic_functionality.py
+++ b/examples/tutorial/v2_inter_container_messaging_and_basic_functionality.py
@@ -50,7 +50,7 @@ class PVAgent(Agent):
         content = reported_feed_in
 
         acl_meta = {
-            "sender_addr": self._context.addr,
+            "sender_addr": self.addr,
             "sender_id": self.aid,
             "performative": Performatives.inform,
         }
@@ -68,7 +68,7 @@ class PVAgent(Agent):
         self.max_feed_in = float(max_feed_in)
         print(f"{self.aid}: Limiting my feed_in to {max_feed_in}")
         self.schedule_instant_task(
-            self._context.send_acl_message(
+            self.send_acl_message(
                 content=None,
                 receiver_addr=sender_addr,
                 receiver_id=sender_id,
@@ -125,13 +125,13 @@ class ControllerAgent(Agent):
         for addr, aid in self.known_agents:
             content = None
             acl_meta = {
-                "sender_addr": self._context.addr,
+                "sender_addr": self.addr,
                 "sender_id": self.aid,
                 "performative": Performatives.request,
             }
             # alternatively we could call send_acl_message here directly and await it
             self.schedule_instant_task(
-                self._context.send_acl_message(
+                self.send_acl_message(
                     content=content,
                     receiver_addr=addr,
                     receiver_id=aid,
@@ -149,14 +149,14 @@ class ControllerAgent(Agent):
         for addr, aid in self.known_agents:
             content = min_feed_in
             acl_meta = {
-                "sender_addr": self._context.addr,
+                "sender_addr": self.addr,
                 "sender_id": self.aid,
                 "performative": Performatives.propose,
             }
 
             # alternatively we could call send_acl_message here directly and await it
             self.schedule_instant_task(
-                self._context.send_acl_message(
+                self.send_acl_message(
                     content=content,
                     receiver_addr=addr,
                     receiver_id=aid,

--- a/examples/tutorial/v3_codecs_and_typing.py
+++ b/examples/tutorial/v3_codecs_and_typing.py
@@ -69,7 +69,7 @@ class PVAgent(Agent):
         msg = FeedInReplyMsg(reported_feed_in)
 
         self.schedule_instant_task(
-            self._context.send_acl_message(
+            self.send_acl_message(
                 content=msg,
                 receiver_addr=sender_addr,
                 receiver_id=sender_id,
@@ -82,7 +82,7 @@ class PVAgent(Agent):
         msg = MaxFeedInAck()
 
         self.schedule_instant_task(
-            self._context.send_acl_message(
+            self.send_acl_message(
                 content=msg,
                 receiver_addr=sender_addr,
                 receiver_id=sender_id,
@@ -132,11 +132,11 @@ class ControllerAgent(Agent):
         # ask pv agent feed-ins
         for addr, aid in self.known_agents:
             msg = AskFeedInMsg()
-            acl_meta = {"sender_addr": self._context.addr, "sender_id": self.aid}
+            acl_meta = {"sender_addr": self.addr, "sender_id": self.aid}
 
             # alternatively we could call send_acl_message here directly and await it
             self.schedule_instant_task(
-                self._context.send_acl_message(
+                self.send_acl_message(
                     content=msg,
                     receiver_addr=addr,
                     receiver_id=aid,
@@ -153,11 +153,11 @@ class ControllerAgent(Agent):
 
         for addr, aid in self.known_agents:
             msg = SetMaxFeedInMsg(min_feed_in)
-            acl_meta = {"sender_addr": self._context.addr, "sender_id": self.aid}
+            acl_meta = {"sender_addr": self.addr, "sender_id": self.aid}
 
             # alternatively we could call send_acl_message here directly and await it
             self.schedule_instant_task(
-                self._context.send_acl_message(
+                self.send_acl_message(
                     content=msg,
                     receiver_addr=addr,
                     receiver_id=aid,

--- a/mango/agent/core.py
+++ b/mango/agent/core.py
@@ -269,6 +269,8 @@ class AgentDelegates:
         :type coroutine_creator:  Coroutine Function
         :param delay: delay in between the cycles
         :type delay: float
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -283,6 +285,8 @@ class AgentDelegates:
         :type coroutine_func:  Coroutine Function
         :param delay: delay in between the cycles
         :type delay: float
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -299,6 +303,8 @@ class AgentDelegates:
         :type coroutine_creator:  Coroutine Function
         :param recurrency: recurrency rule to calculate next event
         :type recurrency: dateutil.rrule.rrule
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -318,6 +324,8 @@ class AgentDelegates:
         :type coroutine_creator:  Coroutine Function
         :param recurrency: recurrency rule to calculate next event
         :type recurrency: dateutil.rrule.rrule
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -333,6 +341,8 @@ class AgentDelegates:
 
         :param coroutine_creator: coroutine_creator creating coroutine to be scheduled
         :type coroutine_creator:
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -345,6 +355,8 @@ class AgentDelegates:
 
         :param coroutine: coroutine to be scheduled
         :type coroutine:
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """

--- a/mango/messages/message.py
+++ b/mango/messages/message.py
@@ -26,6 +26,7 @@ class ACLMessage:
         sender_addr=None,
         receiver_id=None,
         receiver_addr=None,
+        reply_to=None,
         conversation_id=None,
         performative=None,
         content=None,
@@ -60,6 +61,7 @@ class ACLMessage:
         self.sender_addr = sender_addr
         self.receiver_id = receiver_id
         self.receiver_addr = receiver_addr
+        self.reply_to = reply_to
         self.content = content
         self.performative = performative
         self.conversation_id = conversation_id
@@ -81,6 +83,7 @@ class ACLMessage:
             "sender_addr": self.sender_addr,
             "receiver_id": self.receiver_id,
             "receiver_addr": self.receiver_addr,
+            "reply_to": self.reply_to,
             "performative": self.performative,
             "conversation_id": self.conversation_id,
             "content": self.content,
@@ -117,6 +120,7 @@ class ACLMessage:
         acl.sender_id = msg.sender_id if msg.sender_id else None
         acl.receiver_id = msg.receiver_id if msg.receiver_id else None
         acl.conversation_id = msg.conversation_id if msg.conversation_id else None
+        acl.reply_to = msg.reply_to if msg.reply_to else None
         acl.performative = Performatives(msg.performative) if msg.performative else None
         acl.protocol = msg.protocol if msg.protocol else None
         acl.language = msg.language if msg.language else None

--- a/mango/util/scheduling.py
+++ b/mango/util/scheduling.py
@@ -521,6 +521,8 @@ class Scheduler:
         :type coroutine: Coroutine
         :param timestamp: timestamp defining when the task should start (unix timestamp)
         :type timestamp: float
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -540,6 +542,8 @@ class Scheduler:
 
         :param coroutine: coroutine to be scheduled
         :type coroutine:
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -560,6 +564,8 @@ class Scheduler:
         :type coroutine_func:  Coroutine Function
         :param delay: delay in between the cycles
         :type delay: float
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -583,6 +589,8 @@ class Scheduler:
         :type coroutine_func:  Coroutine Function
         :param recurrency: recurrency rule to calculate next event
         :type recurrency: dateutil.rrule.rrule
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -613,6 +621,8 @@ class Scheduler:
         :type condition_func: lambda () -> bool
         :param lookup_delay: delay between checking the condition [s]
         :type lookup_delay: float
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """
@@ -631,12 +641,14 @@ class Scheduler:
     def schedule_awaiting_task(
         self, coroutine, awaited_coroutine, on_stop=None, src=None
     ):
-        """Schedule a task at specified datetime.
+        """Schedule a task after future of other task returned.
 
         :param coroutine: coroutine to be scheduled
         :type coroutine: Coroutine
-        :param date_time: datetime defining when the task should start
-        :type date_time: datetime
+        :param awaited_coroutine: datetime defining when the task should start
+        :type awaited_coroutine: asyncio.Future
+        :param on_stop: coroutine to run on stop
+        :type on_stop: Object
         :param src: creator of the task
         :type src: Object
         """

--- a/tests/integration_tests/test_single_container_termination.py
+++ b/tests/integration_tests/test_single_container_termination.py
@@ -14,7 +14,7 @@ class Caller(Agent):
         super().__init__(container)
         self.schedule_timestamp_task(
             coroutine=self.send_hello_world(receiver_addr, receiver_id),
-            timestamp=self._context.current_timestamp + 5,
+            timestamp=self.current_timestamp + 5,
         )
         self.i = 0
 
@@ -28,7 +28,7 @@ class Caller(Agent):
         self.i += 1
         if self.i < 100:
             self.schedule_instant_acl_message(
-                receiver_addr=self._context.addr, receiver_id="agent0", content=self.i
+                receiver_addr=self.addr, receiver_id="agent0", content=self.i
             )
 
 
@@ -39,7 +39,7 @@ class Receiver(Agent):
     def handle_message(self, content, meta):
         print(f"{self.aid} Received a message with the following content {content}.")
         self.schedule_instant_acl_message(
-            receiver_addr=self._context.addr, receiver_id="agent1", content=content
+            receiver_addr=self.addr, receiver_id="agent1", content=content
         )
 
 

--- a/tests/unit_tests/core/test_agent.py
+++ b/tests/unit_tests/core/test_agent.py
@@ -44,9 +44,7 @@ async def test_send_message():
     agent = MyAgent(c)
     agent2 = MyAgent(c)
 
-    await agent.send_message(
-        "", receiver_addr=agent._context.addr, receiver_id=agent2.aid
-    )
+    await agent.send_message("", receiver_addr=agent.addr, receiver_id=agent2.aid)
     msg = await agent2.inbox.get()
     _, content, meta = msg
     agent2.handle_message(content=content, meta=meta)
@@ -63,9 +61,7 @@ async def test_send_acl_message():
     agent = MyAgent(c)
     agent2 = MyAgent(c)
 
-    await agent.send_acl_message(
-        "", receiver_addr=agent._context.addr, receiver_id=agent2.aid
-    )
+    await agent.send_acl_message("", receiver_addr=agent.addr, receiver_id=agent2.aid)
     msg = await agent2.inbox.get()
     _, content, meta = msg
     agent2.handle_message(content=content, meta=meta)
@@ -82,9 +78,7 @@ async def test_schedule_message():
     agent = MyAgent(c)
     agent2 = MyAgent(c)
 
-    agent.schedule_instant_message(
-        "", receiver_addr=agent._context.addr, receiver_id=agent2.aid
-    )
+    agent.schedule_instant_message("", receiver_addr=agent.addr, receiver_id=agent2.aid)
     msg = await agent2.inbox.get()
     _, content, meta = msg
     agent2.handle_message(content=content, meta=meta)
@@ -102,7 +96,7 @@ async def test_schedule_acl_message():
     agent2 = MyAgent(c)
 
     agent.schedule_instant_acl_message(
-        "", receiver_addr=agent._context.addr, receiver_id=agent2.aid
+        "", receiver_addr=agent.addr, receiver_id=agent2.aid
     )
     msg = await agent2.inbox.get()
     _, content, meta = msg

--- a/tests/unit_tests/core/test_external_scheduling_container.py
+++ b/tests/unit_tests/core/test_external_scheduling_container.py
@@ -191,7 +191,7 @@ class SelfSendAgent(Agent):
         # send message to yourself if necessary
         if self.no_received_msg < self.final_no:
             self.schedule_instant_acl_message(
-                receiver_addr=self._context.addr, receiver_id=self.aid, content=content
+                receiver_addr=self.addr, receiver_id=self.aid, content=content
             )
         else:
             self.schedule_instant_acl_message(

--- a/tests/unit_tests/test_agents.py
+++ b/tests/unit_tests/test_agents.py
@@ -30,7 +30,7 @@ class PingPongAgent(Agent):
                 content="pong",
                 receiver_addr=(receiver_host, receiver_port),
                 receiver_id=receiver_id,
-                acl_metadata={"sender_addr": self._context.addr, "sender_id": self.aid},
+                acl_metadata={"sender_addr": self.addr, "sender_id": self.aid},
             )
             self.sending_tasks.append(t)
 
@@ -55,7 +55,7 @@ class PingPongAgent(Agent):
             content="ping",
             receiver_addr=other_addr,
             receiver_id=other_id,
-            acl_metadata={"sender_addr": self._context.addr, "sender_id": self.aid},
+            acl_metadata={"sender_addr": self.addr, "sender_id": self.aid},
         )
         assert success
 


### PR DESCRIPTION
This PR includes 3 commits with fixes:

* the agent in the example should `reply_with` a message type and not `reply_by` (which would require a time, by which an answer is expected) - see: http://www.fipa.org/specs/fipa00061/SC00061G.html#_Toc26669716
* instead of accessing the `_context` fields, one should use the public API in the examples and tests, whenever possible (related MR on Gitlab: https://gitlab.com/mango-agents/mango/-/merge_requests/95 )
* the `on_stop` param was missing in some places, so I added it to match the function signature

If required I can split the three Commits into three PRs.