### PR TITLE
Custom clock on External connection without port

### DIFF
--- a/mango/container/external_coupling.py
+++ b/mango/container/external_coupling.py
@@ -30,14 +30,14 @@ class ExternalSchedulingContainerOutput:
 class ExternalSchedulingContainer(Container):
     """ """
 
-    clock: ExternalClock  # type hint
-
     def __init__(
         self,
         *,
         addr: str,
         codec: Codec,
         loop: asyncio.AbstractEventLoop,
+        clock: ExternalClock = None,
+        **kwargs,
     ):
         """
         Initializes a ExternalSchedulingContainer. Do not directly call this method but use
@@ -47,14 +47,16 @@ class ExternalSchedulingContainer(Container):
         :param loop: Current event loop
         proto as codec
         """
+        if not clock:
+            clock = ExternalClock()
 
-        clock = ExternalClock()
         super().__init__(
             addr=addr,
+            name=addr,
             codec=codec,
             loop=loop,
-            name=addr,
             clock=clock,
+            **kwargs,
         )
 
         self.running = True
@@ -116,7 +118,7 @@ class ExternalSchedulingContainer(Container):
     ) -> ExternalSchedulingContainerOutput:
         if self.message_buffer:
             logger.warning(
-                "There are messages in teh message buffer to be sent, at the start when step was called."
+                "There are messages in the message buffer to be sent, at the start when step was called."
             )
 
         self.current_start_time_of_step = time.time()

--- a/mango/container/factory.py
+++ b/mango/container/factory.py
@@ -20,14 +20,14 @@ EXTERNAL_CONNECTION = "external_connection"
 
 
 async def create(
-        *,
-        connection_type: str = "tcp",
-        codec: Codec = None,
-        clock: Clock = None,
-        addr: Optional[Union[str, Tuple[str, int]]] = None,
-        copy_internal_messages: bool = False,
-        mqtt_kwargs: Dict[str, Any] = None,
-        **kwargs: Dict[str, Any],
+    *,
+    connection_type: str = "tcp",
+    codec: Codec = None,
+    clock: Clock = None,
+    addr: Optional[Union[str, Tuple[str, int]]] = None,
+    copy_internal_messages: bool = False,
+    mqtt_kwargs: Dict[str, Any] = None,
+    **kwargs: Dict[str, Any],
 ) -> Container:
     """
     This method is called to instantiate a container instance, either
@@ -74,7 +74,9 @@ async def create(
         return container
 
     if connection_type == EXTERNAL_CONNECTION:
-        return ExternalSchedulingContainer(addr=addr, loop=loop, codec=codec)
+        return ExternalSchedulingContainer(
+            addr=addr, loop=loop, codec=codec, clock=clock
+        )
 
     if connection_type == MQTT_CONNECTION:
         # get and check relevant kwargs from mqtt_kwargs
@@ -102,7 +104,7 @@ async def create(
 
         # check if addr is a valid topic without wildcards
         if addr is not None and (
-                not isinstance(addr, str) or "#" in addr or "+" in addr
+            not isinstance(addr, str) or "#" in addr or "+" in addr
         ):
             raise ValueError(
                 "addr is not set correctly. It is used as "


### PR DESCRIPTION
This allows to run a simulation with an ExternalClock without allocation of a port.
If no clock is given, a new `ExternalClock` is created.

This is useful if the `external_connection` container is used in cases where an external clock is already set through other ways.

Futhermore, a working implementation of the `as_agent_process` method is provided, so that the `external_connection` provides the same features as the `tcp` connection does.

Also see here for the former PR on the gitlab-mango-org:
https://gitlab.com/mango-agents/mango/-/merge_requests/91