### PR TITLE
Improve usage of DataContainer by adding get and update

### DIFF
--- a/mango/agent/role.py
+++ b/mango/agent/role.py
@@ -43,8 +43,21 @@ class DataContainer:
     def __getitem__(self, key):
         return self.__getattribute__(key)
 
+    def __setitem__(self, key, newvalue):
+        self.__setattr__(key, newvalue)
+
     def __contains__(self, key):
         return hasattr(self, key)
+
+    def get(self, key):
+        if key in self:
+            return self[key]
+        else:
+            return None
+
+    def update(self, data: dict):
+        for k, v in data.items():
+            self.__setattr__(k, v)
 
 
 class RoleContext:

--- a/tests/unit_tests/role/role_test.py
+++ b/tests/unit_tests/role/role_test.py
@@ -144,3 +144,16 @@ def test_emit_event():
     # THEN
     assert ex_role2.event == event
     assert ex_role2.source == ex_role
+
+def test_data_container():
+    # GIVEN
+    data_container = DataContainer()
+    data_container["abc"] = "123"
+    data_container.update({
+        "cba": 123
+    })
+
+    # WHEN THEN
+    assert data_container.cba == 123
+    assert data_container.get("abc") == "123"
+    assert data_container.get("bca") is None


### PR DESCRIPTION
This makes it easier to check if a value exists in the DataContainer.

I hope, that this is more acceptable than my previous attempt of adding a method to retrieve a value if it exists in the DataContainer and update values if they exist.

related MR from GitLab: https://gitlab.com/mango-agents/mango/-/merge_requests/73