### PR TITLE
add feature to not wait for tasks of a given source

### DIFF
--- a/mango/util/termination_detection.py
+++ b/mango/util/termination_detection.py
@@ -19,7 +19,7 @@ def unfinished_task_count(container: Container):
     return unfinished_tasks
 
 
-async def tasks_complete_or_sleeping(container: Container):
+async def tasks_complete_or_sleeping(container: Container, except_sources=["no_wait"]):
     sleeping_tasks = []
     task_list = []
     await container.inbox.join()
@@ -28,6 +28,7 @@ async def tasks_complete_or_sleeping(container: Container):
         task_list.extend(agent._scheduler._scheduled_tasks)
         task_list.extend(agent._scheduler._scheduled_process_tasks)
 
+    task_list = list(filter(lambda x: x[3] not in except_sources, task_list))
     while len(task_list) > len(sleeping_tasks):
         await container.inbox.join()
         for scheduled_task, task, _, _ in task_list:
@@ -48,3 +49,4 @@ async def tasks_complete_or_sleeping(container: Container):
             await agent.inbox.join()
             task_list.extend(agent._scheduler._scheduled_tasks)
             task_list.extend(agent._scheduler._scheduled_process_tasks)
+        task_list = list(filter(lambda x: x[3] not in except_sources, task_list))


### PR DESCRIPTION
For example, having a Task which writes results into the database every x steps of the simulation, this task might not be required for the simulation itself and should therefore not be awaited by the termination detection.

This is implemented by making it possible to exclude these tasks by source.
Having a default of "no_wait" as a source, for ease of configuration.

This makes it possible to let background tasks not slow down the general simulation.

An Agent can schedule such a background task using something like:

```python
from dateutil import rrule as rr
recurrency_task = rr.rrule(
    freq=rr.Daily,
    interval=3,
    dtstart=sim_start,
    until=sim_end,
    cache=True,
)

self.schedule_recurrent_task(
    self.my_function, recurrency_task, src="no_wait" # <-- this excludes the task from waiting
)
```