### PR TITLE
Allow multiple agent_processes with ExternalClock

### DIFF
--- a/.github/workflows/test-mango.yml
+++ b/.github/workflows/test-mango.yml
@@ -8,13 +8,18 @@ permissions:
 jobs: 
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install virtualenv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.9
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/examples/distributed_clock/clock_manager.py
+++ b/examples/distributed_clock/clock_manager.py
@@ -116,7 +116,7 @@ async def main(start):
     market.add_role(OneSidedMarketRole(demand=1000, receiver_ids=receiver_ids))
 
     clock_agent = DistributedClockManager(
-        c, receiver_clock_addresses=[other_container_addr]
+        c, receiver_clock_addresses=[(other_container_addr, "clock_agent")]
     )
 
     if isinstance(clock, ExternalClock):

--- a/mango/util/distributed_clock.py
+++ b/mango/util/distributed_clock.py
@@ -12,7 +12,7 @@ class ClockAgent(Agent):
 
 
 class DistributedClockManager(ClockAgent):
-    def __init__(self, container, receiver_clock_addresses: list):
+    def __init__(self, container, receiver_clock_addresses: list[tuple]):
         super().__init__(container, "clock")
         self.receiver_clock_addresses = receiver_clock_addresses
         self.schedules = []
@@ -35,12 +35,12 @@ class DistributedClockManager(ClockAgent):
             logger.warning("got another message from agent %s", sender_addr)
 
     async def broadcast(self, message, add_futures=True):
-        for receiver_addr in self.receiver_clock_addresses:
+        for receiver_addr, receiver_aid in self.receiver_clock_addresses:
             logger.debug("clockmanager send: %s - %s", message, receiver_addr)
             send_worked = await self.send_acl_message(
                 message,
                 receiver_addr,
-                "clock_agent",
+                receiver_aid,
                 acl_metadata={"sender_id": self.aid},
             )
             if send_worked and add_futures:
@@ -77,8 +77,8 @@ class DistributedClockManager(ClockAgent):
 
 
 class DistributedClockAgent(ClockAgent):
-    def __init__(self, container):
-        super().__init__(container, "clock_agent")
+    def __init__(self, container, suggested_aid="clock_agent"):
+        super().__init__(container, suggested_aid=suggested_aid)
         self.stopped = asyncio.Future()
 
     def handle_message(self, content: float, meta):

--- a/mango/util/distributed_clock.py
+++ b/mango/util/distributed_clock.py
@@ -12,7 +12,7 @@ class ClockAgent(Agent):
 
 
 class DistributedClockManager(ClockAgent):
-    def __init__(self, container, receiver_clock_addresses: list[tuple]):
+    def __init__(self, container, receiver_clock_addresses: list):
         super().__init__(container, "clock")
         self.receiver_clock_addresses = receiver_clock_addresses
         self.schedules = []

--- a/mango/util/distributed_clock.py
+++ b/mango/util/distributed_clock.py
@@ -26,7 +26,7 @@ class DistributedClockManager(ClockAgent):
 
         logger.debug("clockmanager: %s from %s", content, sender_addr)
         if content:
-            assert isinstance(content, float), f"{content} was {type(content)}"
+            assert isinstance(content, (int, float)), f"{content} was {type(content)}"
             self.schedules.append(content)
 
         if not self.futures[sender_addr].done():

--- a/mango/util/distributed_clock.py
+++ b/mango/util/distributed_clock.py
@@ -71,6 +71,10 @@ class DistributedClockManager(ClockAgent):
         else:
             logger.warning("no new events, time stands still")
             next_event = self._scheduler.clock.time
+
+        if next_event < self._scheduler.clock.time:
+            logger.warning("%s: got old event, time stands still", self.aid)
+            next_event = self._scheduler.clock.time
         logger.debug("next event at %s", next_event)
         self.schedule_instant_task(coroutine=self.broadcast(next_event))
         return next_event

--- a/tests/integration_tests/test_distributed_clock.py
+++ b/tests/integration_tests/test_distributed_clock.py
@@ -47,7 +47,7 @@ async def setup_and_run_test_case(connection_type, codec):
 
     clock_agent = DistributedClockAgent(container_ag)
     clock_manager = DistributedClockManager(
-        container_man, receiver_clock_addresses=[repl_addr]
+        container_man, receiver_clock_addresses=[(repl_addr, "clock_agent")]
     )
 
     # increasing the time


### PR DESCRIPTION
This PR makes it possible to sync an external clock using the `as_agent_process` with multiple additional agent_processes.

As each Agent running in a separate shadow container needs to have a synchronized clock, we need to add a ClockAgent to each of the shadow containers as well.
As one container can have multiple shadow container (multiple agents running in separate as_agent_process), but all these shadow container have the same `addr`, we need to give different names for the ClockAgents.

This is now possible, using something like this:


```python
def creator(container):
    myRole = myRole()
    agent = RoleAgent(
        container,
        suggested_aid="myRoleAgent",
        suspendable_tasks=False,
    )
    agent.add_role(myRole)
    DistributedClockAgent(container)

await myContainer.as_agent_process(agent_creator=creator)

def creator(container):
    myRole = myRole()
    agent = RoleAgent(
        container,
        suggested_aid="myRoleAgent",
        suspendable_tasks=False,
    )
    agent.add_role(myRole)
    DistributedClockAgent(container, suggested_aid="clock_agent2")

await myContainer.as_agent_process(agent_creator=creator)

clock_manager = DistributedClockManager(
    myContainer, receiver_clock_addresses=[(myContainer.addr, "clock_agent"), (myContainer.addr, "clock_agent2")]
)
```
