### PR TITLE
Improve API-Ref on ReadTheDocs

### DIFF
--- a/docs/source/api_ref/index.rst
+++ b/docs/source/api_ref/index.rst
@@ -5,10 +5,22 @@ API reference
 The API reference provides detailed descriptions of mango's classes and
 functions.
 
+Subpackages
+-----------
+
 .. toctree::
-   :glob:
    :maxdepth: 2
 
-   mango.core/index
-   mango.messages/index
-   mango.modules/index
+   mango.agent
+   mango.container
+   mango.messages
+   mango.modules
+   mango.util
+
+Module contents
+---------------
+
+.. automodule:: mango
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_ref/mango.agent.rst
+++ b/docs/source/api_ref/mango.agent.rst
@@ -1,0 +1,29 @@
+mango.agent package
+===================
+
+Submodules
+----------
+
+mango.agent.core module
+-----------------------
+
+.. automodule:: mango.agent.core
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.agent.role module
+-----------------------
+
+.. automodule:: mango.agent.role
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mango.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_ref/mango.container.rst
+++ b/docs/source/api_ref/mango.container.rst
@@ -1,0 +1,61 @@
+mango.container package
+=======================
+
+Submodules
+----------
+
+mango.container.core module
+---------------------------
+
+.. automodule:: mango.container.core
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.container.external\_coupling module
+-----------------------------------------
+
+.. automodule:: mango.container.external_coupling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.container.factory module
+------------------------------
+
+.. automodule:: mango.container.factory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.container.mqtt module
+---------------------------
+
+.. automodule:: mango.container.mqtt
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.container.protocol module
+-------------------------------
+
+.. automodule:: mango.container.protocol
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.container.tcp module
+--------------------------
+
+.. automodule:: mango.container.tcp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mango.container
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_ref/mango.core/index.rst
+++ b/docs/source/api_ref/mango.core/index.rst
@@ -1,8 +1,0 @@
-Modules in mango.core
-=====================
-
-.. toctree::
-   :glob:
-   :maxdepth: 2
-
-   mango.core*

--- a/docs/source/api_ref/mango.core/mango.core.agent.rst
+++ b/docs/source/api_ref/mango.core/mango.core.agent.rst
@@ -1,5 +1,0 @@
-``mango.core.agent``
-================
-
-.. automodule:: mango.core.agent
-   :members:

--- a/docs/source/api_ref/mango.core/mango.core.container.rst
+++ b/docs/source/api_ref/mango.core/mango.core.container.rst
@@ -1,5 +1,0 @@
-``mango.core.container``
-================
-
-.. automodule:: mango.core.container
-   :members:

--- a/docs/source/api_ref/mango.core/mango.core.container_protocols.rst
+++ b/docs/source/api_ref/mango.core/mango.core.container_protocols.rst
@@ -1,5 +1,0 @@
-``mango.core.container_protocols``
-================
-
-.. automodule:: mango.core.container_protocols
-   :members:

--- a/docs/source/api_ref/mango.messages.rst
+++ b/docs/source/api_ref/mango.messages.rst
@@ -1,0 +1,45 @@
+mango.messages package
+======================
+
+Submodules
+----------
+
+mango.messages.acl\_message\_pb2 module
+---------------------------------------
+
+.. automodule:: mango.messages.acl_message_pb2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.messages.codecs module
+----------------------------
+
+.. automodule:: mango.messages.codecs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.messages.message module
+-----------------------------
+
+.. automodule:: mango.messages.message
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.messages.other\_proto\_msgs\_pb2 module
+---------------------------------------------
+
+.. automodule:: mango.messages.other_proto_msgs_pb2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mango.messages
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_ref/mango.messages/index.rst
+++ b/docs/source/api_ref/mango.messages/index.rst
@@ -1,8 +1,0 @@
-Modules in mango.messages
-=====================
-
-.. toctree::
-   :glob:
-   :maxdepth: 2
-
-   mango.messages*

--- a/docs/source/api_ref/mango.messages/mango.messages.codecs.rst
+++ b/docs/source/api_ref/mango.messages/mango.messages.codecs.rst
@@ -1,5 +1,0 @@
-``mango.messages.codecs``
-================
-
-.. automodule:: mango.messages.codecs
-   :members:

--- a/docs/source/api_ref/mango.messages/mango.messages.message.rst
+++ b/docs/source/api_ref/mango.messages/mango.messages.message.rst
@@ -1,5 +1,0 @@
-``mango.messages.message``
-================
-
-.. automodule:: mango.messages.message
-   :members:

--- a/docs/source/api_ref/mango.modules.rst
+++ b/docs/source/api_ref/mango.modules.rst
@@ -1,0 +1,45 @@
+mango.modules package
+=====================
+
+Submodules
+----------
+
+mango.modules.base\_module module
+---------------------------------
+
+.. automodule:: mango.modules.base_module
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.modules.mqtt\_module module
+---------------------------------
+
+.. automodule:: mango.modules.mqtt_module
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.modules.rabbit\_module module
+-----------------------------------
+
+.. automodule:: mango.modules.rabbit_module
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.modules.zero\_module module
+---------------------------------
+
+.. automodule:: mango.modules.zero_module
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mango.modules
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api_ref/mango.modules/index.rst
+++ b/docs/source/api_ref/mango.modules/index.rst
@@ -1,8 +1,0 @@
-Modules in mango.modules
-=====================
-
-.. toctree::
-   :glob:
-   :maxdepth: 2
-
-   mango.modules*

--- a/docs/source/api_ref/mango.modules/mango.modules.base_module.rst
+++ b/docs/source/api_ref/mango.modules/mango.modules.base_module.rst
@@ -1,5 +1,0 @@
-``mango.modules.base_module``
-================
-
-.. automodule:: mango.modules.base_module
-   :members:

--- a/docs/source/api_ref/mango.modules/mango.modules.mqtt_module.rst
+++ b/docs/source/api_ref/mango.modules/mango.modules.mqtt_module.rst
@@ -1,5 +1,0 @@
-``mango.modules.mqtt_module``
-================
-
-.. automodule:: mango.modules.mqtt_module
-   :members:

--- a/docs/source/api_ref/mango.modules/mango.modules.rabbit_module.rst
+++ b/docs/source/api_ref/mango.modules/mango.modules.rabbit_module.rst
@@ -1,5 +1,0 @@
-``mango.modules.rabbit_module``
-================
-
-.. automodule:: mango.modules.rabbit_module
-   :members:

--- a/docs/source/api_ref/mango.modules/mango.modules.zero_module.rst
+++ b/docs/source/api_ref/mango.modules/mango.modules.zero_module.rst
@@ -1,5 +1,0 @@
-``mango.modules.zero_module``
-================
-
-.. automodule:: mango.modules.zero_module
-   :members:

--- a/docs/source/api_ref/mango.util.rst
+++ b/docs/source/api_ref/mango.util.rst
@@ -1,0 +1,53 @@
+mango.util package
+==================
+
+Submodules
+----------
+
+mango.util.clock module
+-----------------------
+
+.. automodule:: mango.util.clock
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.util.distributed\_clock module
+------------------------------------
+
+.. automodule:: mango.util.distributed_clock
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.util.multiprocessing module
+---------------------------------
+
+.. automodule:: mango.util.multiprocessing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.util.scheduling module
+----------------------------
+
+.. automodule:: mango.util.scheduling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+mango.util.termination\_detection module
+----------------------------------------
+
+.. automodule:: mango.util.termination_detection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: mango.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/customizing-container.rst
+++ b/docs/source/customizing-container.rst
@@ -1,6 +1,6 @@
-========
+=============================
 Customizing a mango container
-========
+=============================
 
 A mango container can be customized regarding its way it connects to other containers.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,5 +1,5 @@
 Installation
-========
+============
 *mango* requires Python >= 3.8 and runs on Linux, OSX and Windows.
 For installation of mango you could use
 virtualenv__ which can create isolated Python environments for different projects.
@@ -11,7 +11,7 @@ __ https://virtualenv.pypa.io/en/latest/#
 __ https://virtualenvwrapper.readthedocs.io/en/latest/index.html
 
 Installation with pip
------------------------
+---------------------
 Once you have created a virtual environment you can just run pip__ to install it:
 
 .. code-block:: console
@@ -20,9 +20,9 @@ Once you have created a virtual environment you can just run pip__ to install it
 
 __ https://pip.pypa.io/en/stable/
 
-..
+
 Installation from source
------------------------
+------------------------
 To install from source, simply check out this repository and install in editable mode using pip:
 
 .. code-block:: console
@@ -30,7 +30,7 @@ To install from source, simply check out this repository and install in editable
     $ pip install -e .
 
 Using a local message broker
------------------------
+----------------------------
 If you want to make use of the functional mqtt modules to modularize your agent,
 you must have a local message broker running on your system.
 We recommend Mosquitto__. On Debian/Ubuntu it can be installed as follows:

--- a/docs/source/scheduling.rst
+++ b/docs/source/scheduling.rst
@@ -1,6 +1,6 @@
-==========
+====================
 Scheduling and Clock
-==========
+====================
 
 When implementing agents including proactive behavior there are some typical types of tasks you might want to create. For example it might be desired to let the agent check every minute whether some resources are available, or often you just want to execute a task at a specified time. To help achieving this kind of goals mango exposes the scheduling API.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -723,6 +723,7 @@ In your ``main``, you can replace the line:
 .. code-block:: python
 
         await controller_agent.run()
+
 with the following line:
 
 .. code-block:: python


### PR DESCRIPTION
Currently the API-Ref was broken, as it was not updated during the refactorings and restructurings of the code base.

closes #67 

This is fixed by running:

`sphinx-apidoc -o docs/source -Fa mango` to create current automodule files

build and improve the docs using
`make -C docs html`
and inspect the result using:
`python -m http.server --directory docs/build/html`

There are still various warnings as the documentation is not up to date or has syntax errors, but at least we do have a huge improvement.