### PR TITLE
properly close connection pool and shutdown transport

### DIFF
--- a/.github/workflows/test-mango.yml
+++ b/.github/workflows/test-mango.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/mango/container/protocol.py
+++ b/mango/container/protocol.py
@@ -25,7 +25,7 @@ class ContainerProtocol(asyncio.Protocol):
         super().__init__()
 
         self.codec = codec
-        self.transport = None
+        self.transport = None  # type: _SelectorTransport
         self.container = container
         self._loop = loop
         self._buffer = bytearray()
@@ -44,7 +44,15 @@ class ContainerProtocol(asyncio.Protocol):
         :param exc:
         :return:
         """
+        self.transport.close()
         super().connection_lost(exc)
+
+    def eof_received(self):
+        """
+
+        :return:
+        """
+        return super().eof_received()
 
     def data_received(self, data):
         """

--- a/tests/integration_tests/test_distributed_clock.py
+++ b/tests/integration_tests/test_distributed_clock.py
@@ -63,6 +63,9 @@ async def setup_and_run_test_case(connection_type, codec):
     # did work the second time too
     assert clock_ag.time == 1000
 
+    await clock_manager.shutdown()
+    await clock_agent.shutdown()
+
     # finally shut down
     await asyncio.gather(
         container_man.shutdown(),

--- a/tests/unit_tests/container/test_tcp.py
+++ b/tests/unit_tests/container/test_tcp.py
@@ -4,6 +4,10 @@ from mango.container.tcp import TCPConnectionPool
 from mango.container.protocol import ContainerProtocol
 from mango import create_container
 
+@pytest.mark.asyncio
+async def test_connection_open_close():
+    c = await create_container(addr=("127.0.0.2", 5555), copy_internal_messages=False)
+    await c.shutdown()
 
 @pytest.mark.asyncio
 async def test_connection_pool_obtain_release():
@@ -24,6 +28,7 @@ async def test_connection_pool_obtain_release():
 
     assert connection_pool._available_connections[addr].qsize() == 1
     assert connection_pool._connection_counts[addr] == 1
+    await connection_pool.shutdown()
 
     await c.shutdown()
     await c2.shutdown()
@@ -61,6 +66,7 @@ async def test_connection_pool_double_obtain_release():
 
     assert connection_pool._available_connections[addr].qsize() == 2
     assert connection_pool._connection_counts[addr] == 2
+    await connection_pool.shutdown()
 
     await c.shutdown()
     await c2.shutdown()
@@ -101,6 +107,7 @@ async def test_ttl():
 
     assert connection_pool._available_connections[addr2].qsize() == 1
     assert connection_pool._connection_counts[addr2] == 1
+    await connection_pool.shutdown()
 
     await c.shutdown()
     await c2.shutdown()
@@ -132,6 +139,7 @@ async def test_max_connections():
 
     assert connection_pool._available_connections[addr].qsize() == 1
     assert connection_pool._connection_counts[addr] == 1
+    await connection_pool.shutdown()
 
     await c.shutdown()
     await c2.shutdown()

--- a/tests/unit_tests/role_agent_test.py
+++ b/tests/unit_tests/role_agent_test.py
@@ -174,8 +174,7 @@ async def test_send_ping_pong(num_agents, num_containers):
     # gracefully shutdown
     for a in agents:
         await a.shutdown()
-    for c in containers:
-        await c.shutdown()
+    await asyncio.gather(*[c.shutdown() for c in containers])
 
     assert len(asyncio.all_tasks()) == 1
 
@@ -218,8 +217,7 @@ async def test_send_ping_pong_deactivated_pong(num_agents, num_containers):
     # gracefully shutdown
     for a in agents:
         await a.shutdown()
-    for c in containers:
-        await c.shutdown()
+    await asyncio.gather(*[c.shutdown() for c in containers])
 
     assert len(asyncio.all_tasks()) == 1
 

--- a/tests/unit_tests/test_agents.py
+++ b/tests/unit_tests/test_agents.py
@@ -136,7 +136,6 @@ async def test_send_ping_pong(num_agents, num_containers):
     # gracefully shutdown
     for a in agents:
         await a.shutdown()
-    for c in containers:
-        await c.shutdown()
+    await asyncio.gather(*[c.shutdown() for c in containers])
 
     assert len(asyncio.all_tasks()) == 1


### PR DESCRIPTION
This is needed for wait_closed to terminate starting from 3.12 Before, wait_closed was a noop and did not check for all clients to be closed.

see https://github.com/python/cpython/issues/104344

fixes #89