### PR TITLE
Allow deselect mqtt and fix pytest warnings

### DIFF
--- a/mango/util/scheduling.py
+++ b/mango/util/scheduling.py
@@ -293,7 +293,7 @@ class RecurrentScheduledTask(ScheduledTask):
                 self.notify_sleeping()
                 await sleep_future
                 self.notify_running()
-            await self._coroutine_func()
+                await self._coroutine_func()
 
 
 class ConditionalTask(ScheduledTask):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[tool:pytest]
+
+markers = 
+    mqtt
+
+asyncio_default_fixture_loop_scope = function

--- a/tests/integration_tests/test_distributed_clock.py
+++ b/tests/integration_tests/test_distributed_clock.py
@@ -76,5 +76,6 @@ async def test_tcp_json():
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_mqtt_json():
     await setup_and_run_test_case("mqtt", JSON_CODEC)

--- a/tests/integration_tests/test_message_roundtrip.py
+++ b/tests/integration_tests/test_message_roundtrip.py
@@ -185,15 +185,18 @@ async def test_tcp_fast_json():
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_mqtt_fast_json():
     await setup_and_run_test_case("mqtt", FAST_JSON_CODEC)
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_mqtt_json():
     await setup_and_run_test_case("mqtt", JSON_CODEC)
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_mqtt_proto():
     await setup_and_run_test_case("mqtt", PROTO_CODEC)

--- a/tests/unit_tests/role_agent_test.py
+++ b/tests/unit_tests/role_agent_test.py
@@ -127,7 +127,7 @@ class DeactivateAllRoles(Role):
             self.context.deactivate(r)
 
 
-class TestRole(Role):
+class SampleRole(Role):
     def __init__(self):
         self.setup_called = False
 
@@ -228,7 +228,7 @@ async def test_send_ping_pong_deactivated_pong(num_agents, num_containers):
 async def test_role_add_remove():
     c = await container_factory.create(addr=("127.0.0.2", 5555))
     agent = RoleAgent(c)
-    role = TestRole()
+    role = SampleRole()
     agent.add_role(role)
 
     assert agent._role_handler.roles[0] == role
@@ -243,7 +243,7 @@ async def test_role_add_remove():
 async def test_role_add_remove_context():
     c = await container_factory.create(addr=("127.0.0.2", 5555))
     agent = RoleAgent(c)
-    role = TestRole()
+    role = SampleRole()
     agent._role_context.add_role(role)
 
     assert role.setup_called


### PR DESCRIPTION
allow running tests locally with `pytest -m "not mqtt"`, to deselect the mqtt cases.
Fixes an issue where recurrent jobs were executed twice at the end which should not happen generally.

* fix pytest warnings in scheduling and SampleRole 
* classes with Test as prefix create pytest assumptions
* periodic jobs in scheduling were not cancelled correctly
* reduce scheduling runtime
* fix recurrency scheduling
