### PR TITLE
update paho-mqtt to v2 - adjust method signatures as needed

### DIFF
--- a/mango/container/factory.py
+++ b/mango/container/factory.py
@@ -116,7 +116,7 @@ async def create(
             )
 
         # create paho.Client object for mqtt communication
-        mqtt_messenger: paho.Client = paho.Client(client_id=client_id, **init_kwargs)
+        mqtt_messenger: paho.Client = paho.Client(paho.CallbackAPIVersion.VERSION2, client_id=client_id, **init_kwargs)
 
         # set TLS options if provided
         # expected as a dict:
@@ -129,9 +129,9 @@ async def create(
         connected = asyncio.Future()
 
         # callbacks to check for successful connection
-        def on_con(client, userdata, flags, returncode):
+        def on_con(client, userdata, flags, reason_code, properties):
             logger.info("Connection Callback with the following flags: %s", flags)
-            loop.call_soon_threadsafe(connected.set_result, returncode)
+            loop.call_soon_threadsafe(connected.set_result, reason_code)
 
         mqtt_messenger.on_connect = on_con
 
@@ -192,7 +192,7 @@ async def create(
             subscribed = asyncio.Future()
 
             # set up subscription callback
-            def on_sub(*args):
+            def on_sub(client, userdata, mid, reason_code_list, properties):
                 loop.call_soon_threadsafe(subscribed.set_result, True)
 
             mqtt_messenger.on_subscribe = on_sub

--- a/mango/container/mqtt.py
+++ b/mango/container/mqtt.py
@@ -103,15 +103,15 @@ class MQTTContainer(Container):
 
         self.mqtt_client.on_connect = on_con
 
-        def on_discon(client, userdata, rc):
-            if rc != 0:
+        def on_discon(client, userdata, disconnect_flags, reason_code, properties):
+            if reason_code != 0:
                 logger.warning("Unexpected disconnect from broker. Trying to reconnect")
             else:
                 logger.debug("Successfully disconnected from broker.")
 
         self.mqtt_client.on_disconnect = on_discon
 
-        def on_sub(client, userdata, mid, granted_qos):
+        def on_sub(client, userdata, mid, reason_code_list, properties):
             self.loop.call_soon_threadsafe(self.pending_sub_request.set_result, 0)
 
         self.mqtt_client.on_subscribe = on_sub

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ iniconfig==1.0.1
 more-itertools==8.5.0
 nox==2020.8.22
 packaging==20.4
-paho-mqtt==1.5.1
+paho-mqtt==2.1.0
 pika==1.1.0
 pluggy>=0.13.1
 protobuf==5.27.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.1.4"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    "paho-mqtt==1.5.1",
+    "paho-mqtt>=2.1.0",
     "python-dateutil>=2.9.0",
     "dill>=0.3.8",
     "msgspec>=0.18.6",


### PR DESCRIPTION
This removes a deprecation warning when using mango with a newer version of paho-mqtt.
As paho-mqtt v1 will be deprecated, it makes sense to switch to the new version as soon as possible :)