### PR TITLE
forking for new processes is discouraged and might lead to deadlocks in the child.

### DIFF
--- a/tests/unit_tests/util/scheduling_test.py
+++ b/tests/unit_tests/util/scheduling_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import multiprocessing
 import time
 
 import pytest
@@ -15,6 +16,8 @@ from mango.util.scheduling import (
     Scheduler,
     TimestampScheduledTask,
 )
+
+multiprocessing.set_start_method('spawn', force=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
See https://github.com/python/cpython/issues/84559 and of course
https://pythonspeed.com/articles/python-multiprocessing/

This does only fix the warning which comes up starting from python 3.12 - this config should be used in user code in the beginning somewhere.
We could also set this manually in mango generally, though this leaves the user less choice.

When using the spawn method instead of fork, all process memory has to be pickled first, leaving extra steps when using the serializer methods currently..

I might improve this in this PR as well