### PR TITLE
mqtt: fixup leftover function and adjust to paho-client v2

### DIFF
--- a/mango/container/mqtt.py
+++ b/mango/container/mqtt.py
@@ -95,8 +95,8 @@ class MQTTContainer(Container):
         Sets the callbacks for the mqtt paho client
         """
 
-        def on_con(client, userdata, flags, rc):
-            if rc != 0:
+        def on_con(client, userdata, flags, reason_code, properties):
+            if reason_code != 0:
                 logger.info("Connection attempt to broker failed")
             else:
                 logger.debug("Successfully reconnected to broker.")

--- a/mango/modules/mqtt_module.py
+++ b/mango/modules/mqtt_module.py
@@ -84,24 +84,26 @@ class MQTTModule:
         """
         func(topic=message.topic, payload=message.payload)
 
-    def conn(self, client, userdata, flags, return_code):
+    def conn(self, client, userdata, flags, reason_code, properties):
         # pylint: disable=unused-argument
         """
         Callback method on broker connection on paho mqtt framework
         :param client: the connecting client
         :param userdata: userdata object
         :param flags: returned flags
-        :param return_code: return code
+        :param reason_code: reason code
+        :param properties: properties
         :return: None
         """
 
-    def on_disconnect(self, client, userdata, return_code):
+    def on_disconnect(self, client, userdata, disconnect_flags, reason_code, properties):
         # pylint: disable=unused-argument
         """
         Callback method on broker disconnect on paho mqtt framework
         :param client: the connecting client
         :param userdata: userdata object
-        :param return_code: return code
+        :param reason_code: reason code
+        :param properties: properties
         :return: None
         """
 


### PR DESCRIPTION
Seems like the reconnect is not part of a test for now?
So I had to run into this missing adjustment of the on_connect method signature.

I also adjusted the module, though it currently is not used afaik?