### PR TITLE
Improve distributed clock

### DIFF
--- a/mango/container/factory.py
+++ b/mango/container/factory.py
@@ -218,7 +218,7 @@ async def create(
                     f"Subscription request to {addr} at {broker_addr} "
                     f"did not succeed after {counter * 0.1} seconds."
                 )
-            logger.info("successfully susbsribed to topic")
+            logger.info("successfully subscribed to topic")
 
         # connection and subscription is successful, remove callbacks
         mqtt_messenger.on_subscribe = None

--- a/tests/integration_tests/test_single_container_termination.py
+++ b/tests/integration_tests/test_single_container_termination.py
@@ -3,11 +3,9 @@ import asyncio
 import pytest
 
 from mango import Agent, create_container
-from mango.messages.codecs import JSON
 from mango.util.clock import ExternalClock
 from mango.util.distributed_clock import DistributedClockAgent, DistributedClockManager
 from mango.util.termination_detection import tasks_complete_or_sleeping
-from multiprocessing import Process
 
 
 class Caller(Agent):
@@ -114,7 +112,7 @@ async def distribute_time_test_case(connection_type, codec=None):
     )
     receiver = Receiver(container_ag, init_addr, "agent0")
     caller = Caller(container_man, repl_addr, receiver.aid)
-    
+
 
     assert receiver._scheduler.clock.time == 0
     # first synchronize the clock to the receiver
@@ -192,6 +190,7 @@ async def send_current_time_test_case(connection_type, codec=None):
     )
     receiver = Receiver(container_ag, init_addr, "agent0")
     caller = Caller(container_man, repl_addr, receiver.aid)
+    await tasks_complete_or_sleeping(container_man)
 
     assert receiver._scheduler.clock.time == 0
     # first synchronize the clock to the receiver

--- a/tests/integration_tests/test_single_container_termination.py
+++ b/tests/integration_tests/test_single_container_termination.py
@@ -9,27 +9,38 @@ from mango.util.termination_detection import tasks_complete_or_sleeping
 
 
 class Caller(Agent):
-    def __init__(self, container, receiver_addr, receiver_id, send_self_messages=False):
+    def __init__(self, container, receiver_addr, receiver_id, send_response_messages=False, max_count=100, schedule_timestamp=False):
         super().__init__(container)
         self.schedule_timestamp_task(
             coroutine=self.send_hello_world(receiver_addr, receiver_id),
             timestamp=self.current_timestamp + 5,
         )
         self.i = 0
-        self.send_self_messages = send_self_messages
+        self.send_response_messages = send_response_messages
+        self.max_count = max_count
+        self.schedule_timestamp = schedule_timestamp
+        self.done = asyncio.Future()
 
     async def send_hello_world(self, receiver_addr, receiver_id):
         await self.send_acl_message(
             receiver_addr=receiver_addr, receiver_id=receiver_id, content="Hello World"
         )
 
+    async def send_ordered(self, meta):
+        await self.send_acl_message(
+            receiver_addr=meta["sender_addr"], receiver_id=meta["sender_id"], content=self.i
+        )
+
+
     def handle_message(self, content, meta):
-        print(f"{self.aid} Received a message with the following content {content}.")
         self.i += 1
-        if self.i < 100 and self.send_self_messages:
-            self.schedule_instant_acl_message(
-                receiver_addr=self.addr, receiver_id="agent0", content=self.i
-            )
+        if self.i < self.max_count and self.send_response_messages:
+            if self.schedule_timestamp:
+                self.schedule_timestamp_task(self.send_ordered(meta), self.current_timestamp+5)
+            else:
+                self.schedule_instant_task(self.send_ordered(meta))
+        elif not self.done.done():
+            self.done.set_result(True)
 
 
 class Receiver(Agent):
@@ -39,22 +50,22 @@ class Receiver(Agent):
         self.receiver_id = receiver_id
 
     def handle_message(self, content, meta):
-        print(f"{self.aid} Received a message with the following content {content}.")
         self.schedule_instant_acl_message(
-            receiver_addr=self.receiver_addr or self.addr, receiver_id=self.receiver_id or "agent1", content=content
+            receiver_addr=self.receiver_addr or self.addr, receiver_id=self.receiver_id or "agent1",
+            content=content,
+            acl_metadata={"sender_id": self.aid},
         )
 
 
 @pytest.mark.asyncio
 async def test_termination_single_container():
     clock = ExternalClock(start_time=1000)
-    addr = ("127.0.0.1", 5555)
 
-    c = await create_container(addr=addr, clock=clock)
+    c = await create_container(connection_type="external_connection", clock=clock)
     receiver = Receiver(c)
-    caller = Caller(c, addr, receiver.aid, send_self_messages=True)
+    caller = Caller(c, c.addr, receiver.aid, send_response_messages=True)
     if isinstance(clock, ExternalClock):
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.1)
         clock.set_time(clock.time + 5)
 
     # wait until each agent is done with all tasks at some point
@@ -68,8 +79,149 @@ async def test_termination_single_container():
     # to solve this situation for multiple containers a distributed termination detection
     # is needed
     await tasks_complete_or_sleeping(c)
-    assert caller.i == 100
+    assert caller.i == caller.max_count
     await c.shutdown()
+
+
+async def distribute_ping_pong_test(connection_type, codec=None, max_count=100):
+    init_addr = ("localhost", 1555) if connection_type == "tcp" else "c1"
+    repl_addr = ("localhost", 1556) if connection_type == "tcp" else "c2"
+
+    broker = ("localhost", 1883, 60)
+    mqtt_kwargs_1 = {
+        "client_id": "container_1",
+        "broker_addr": broker,
+        "transport": "tcp",
+    }
+
+    mqtt_kwargs_2 = {
+        "client_id": "container_2",
+        "broker_addr": broker,
+        "transport": "tcp",
+    }
+
+    clock_man = ExternalClock(5)
+    container_man = await create_container(
+        connection_type=connection_type,
+        codec=codec,
+        addr=init_addr,
+        mqtt_kwargs=mqtt_kwargs_1,
+        clock=clock_man,
+    )
+    clock_ag = ExternalClock()
+    container_ag = await create_container(
+        connection_type=connection_type,
+        codec=codec,
+        addr=repl_addr,
+        mqtt_kwargs=mqtt_kwargs_2,
+        clock=clock_ag,
+    )
+
+    clock_agent = DistributedClockAgent(container_ag)
+    clock_manager = DistributedClockManager(
+        container_man, receiver_clock_addresses=[(repl_addr, "clock_agent")]
+    )
+    receiver = Receiver(container_ag, init_addr, "agent0")
+    caller = Caller(container_man, repl_addr, receiver.aid, send_response_messages=True, max_count=max_count)
+
+    clock_man.set_time(clock_man.time+5)
+
+    # we do not have distributed termination detection yet in core
+    assert caller.i < caller.max_count
+
+    await caller.done
+    assert caller.i == caller.max_count
+
+    # finally shut down
+    await asyncio.gather(
+        container_man.shutdown(),
+        container_ag.shutdown(),
+    )
+
+async def distribute_ping_pong_test_timestamp(connection_type, codec=None, max_count=10):
+    init_addr = ("localhost", 1555) if connection_type == "tcp" else "c1"
+    repl_addr = ("localhost", 1556) if connection_type == "tcp" else "c2"
+
+    broker = ("localhost", 1883, 60)
+    mqtt_kwargs_1 = {
+        "client_id": "container_1",
+        "broker_addr": broker,
+        "transport": "tcp",
+    }
+
+    mqtt_kwargs_2 = {
+        "client_id": "container_2",
+        "broker_addr": broker,
+        "transport": "tcp",
+    }
+
+    clock_man = ExternalClock(5)
+    container_man = await create_container(
+        connection_type=connection_type,
+        codec=codec,
+        addr=init_addr,
+        mqtt_kwargs=mqtt_kwargs_1,
+        clock=clock_man,
+    )
+    clock_ag = ExternalClock()
+    container_ag = await create_container(
+        connection_type=connection_type,
+        codec=codec,
+        addr=repl_addr,
+        mqtt_kwargs=mqtt_kwargs_2,
+        clock=clock_ag,
+    )
+
+    clock_agent = DistributedClockAgent(container_ag)
+    clock_manager = DistributedClockManager(
+        container_man, receiver_clock_addresses=[(repl_addr, "clock_agent")]
+    )
+    receiver = Receiver(container_ag, init_addr, "agent0")
+    caller = Caller(container_man, repl_addr, receiver.aid, send_response_messages=True, max_count=max_count, schedule_timestamp=True)
+
+    # we do not have distributed termination detection yet in core
+    assert caller.i < caller.max_count
+
+    import time
+    tt = 0
+    if isinstance(clock_man, ExternalClock):
+        for i in range(caller.max_count):
+            await tasks_complete_or_sleeping(container_man)
+            t = time.time()
+            await clock_manager.send_current_time()
+            next_event = await clock_manager.get_next_event()
+            tt += time.time()-t
+
+            clock_man.set_time(next_event)
+
+    await caller.done
+
+    assert caller.i == caller.max_count
+
+    # finally shut down
+    await asyncio.gather(
+        container_man.shutdown(),
+        container_ag.shutdown(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_distribute_ping_pong_tcp():
+    await distribute_ping_pong_test("tcp")
+
+@pytest.mark.asyncio
+async def test_distribute_ping_pong_mqtt():
+    await distribute_ping_pong_test("mqtt")
+
+@pytest.mark.asyncio
+async def test_distribute_ping_pong_ts_tcp():
+    await distribute_ping_pong_test_timestamp("tcp")
+
+@pytest.mark.asyncio
+async def test_distribute_ping_pong_ts_mqtt():
+    await distribute_ping_pong_test_timestamp("mqtt")
+
+
 
 
 async def distribute_time_test_case(connection_type, codec=None):


### PR DESCRIPTION
* adds method `wait_all_online` which waits until all the given agents in a DistributedClockManager are online. This removes the need to start the agent before the manager and makes it possible to run in docker/k8s tasks.

* this also revealed an interesting timing problem in mqtt when run with

### timing problem

`pytest tests/integration_tests/test_single_container_termination.py --durations=0`


```
1.12s call     tests/integration_tests/test_single_container_termination.py::test_distribute_ping_pong_ts_mqtt
0.96s call     tests/integration_tests/test_single_container_termination.py::test_distribute_time_mqtt
0.81s call     tests/integration_tests/test_single_container_termination.py::test_send_current_time_mqtt
0.71s call     tests/integration_tests/test_single_container_termination.py::test_distribute_ping_pong_mqtt
0.14s call     tests/integration_tests/test_single_container_termination.py::test_termination_single_container
0.05s call     tests/integration_tests/test_single_container_termination.py::test_distribute_ping_pong_tcp
0.02s call     tests/integration_tests/test_single_container_termination.py::test_send_current_time_tcp
0.01s call     tests/integration_tests/test_single_container_termination.py::test_distribute_ping_pong_ts_tcp
0.01s call     tests/integration_tests/test_single_container_termination.py::test_distribute_time_tcp
```

First of all, one can see that the use of MQTT is slower than TCP by an order of magnitudes in these roundtrip tests.

The test `test_distribute_ping_pong_ts` uses the distributed clock to synchronize the clock of distributed containers.
When using MQTT, this has a small delay of 40ms between every time update, while I did not find out where this comes from, even when looking at the code of paho-mqtt and spending a few hours on that.
The test `test_distribute_ping_pong_mqtt` does not use a distributed clock, but directly ping pong using handle message and subscribe.

The delay probably comes from the synchronization of asyncio and the paho-mqtt event loop.

In general, the TCP connection method performs much better, when sending hundreds of roundtrips between two agents in different containers.