### PR TITLE
docs: fix warnings in sphinx docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: "3.7"
+   version: "3.12"
    install:
    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,4 @@
-alabaster==0.7.7
-decorator==4.3.0
-docopt==0.6.2
-docutils==0.16
-imagesize==0.7.1
-Jinja2==2.9
-MarkupSafe==0.23
-Sphinx==4.0.2
-sphinx-rtd-theme==0.5.2
+-e .
+sphinx-rtd-theme>=2.0.0
+pika
+pyzmq

--- a/docs/source/agents-container.rst
+++ b/docs/source/agents-container.rst
@@ -1,6 +1,6 @@
-========
+====================
 Agents and container
-========
+====================
 
 ***************
 mango container
@@ -72,6 +72,7 @@ To improve multicore utilization, mango provides a way to distribute agents to p
 register the agent in a slightly different way.
 
 .. code-block:: python3
+
     process_handle = await main_container.as_agent_process(
         agent_creator=lambda sub_container: TestAgent(
             container, aid_main_agent, suggested_aid=f"process_agent1"
@@ -85,6 +86,7 @@ with the agent directly from the main process. If you want to interact with the 
 dispatch a task in the agent process using `dispatch_to_agent_process`.
 
 .. code-block:: python3
+
     main_container.dispatch_to_agent_process(
         pid,
         your_function, # will be called with the mirror container + x as arguments

--- a/docs/source/api_ref/index.rst
+++ b/docs/source/api_ref/index.rst
@@ -16,11 +16,3 @@ Subpackages
    mango.messages
    mango.modules
    mango.util
-
-Module contents
----------------
-
-.. automodule:: mango
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/api_ref/mango.agent.rst
+++ b/docs/source/api_ref/mango.agent.rst
@@ -1,9 +1,6 @@
 mango.agent package
 ===================
 
-Submodules
-----------
-
 mango.agent.core module
 -----------------------
 
@@ -16,14 +13,6 @@ mango.agent.role module
 -----------------------
 
 .. automodule:: mango.agent.role
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: mango.agent
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api_ref/mango.container.rst
+++ b/docs/source/api_ref/mango.container.rst
@@ -1,9 +1,6 @@
 mango.container package
 =======================
 
-Submodules
-----------
-
 mango.container.core module
 ---------------------------
 
@@ -48,14 +45,6 @@ mango.container.tcp module
 --------------------------
 
 .. automodule:: mango.container.tcp
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: mango.container
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api_ref/mango.messages.rst
+++ b/docs/source/api_ref/mango.messages.rst
@@ -1,9 +1,6 @@
 mango.messages package
 ======================
 
-Submodules
-----------
-
 mango.messages.acl\_message\_pb2 module
 ---------------------------------------
 
@@ -32,14 +29,6 @@ mango.messages.other\_proto\_msgs\_pb2 module
 ---------------------------------------------
 
 .. automodule:: mango.messages.other_proto_msgs_pb2
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: mango.messages
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api_ref/mango.modules.rst
+++ b/docs/source/api_ref/mango.modules.rst
@@ -1,9 +1,6 @@
 mango.modules package
 =====================
 
-Submodules
-----------
-
 mango.modules.base\_module module
 ---------------------------------
 
@@ -32,14 +29,6 @@ mango.modules.zero\_module module
 ---------------------------------
 
 .. automodule:: mango.modules.zero_module
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: mango.modules
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api_ref/mango.util.rst
+++ b/docs/source/api_ref/mango.util.rst
@@ -1,9 +1,6 @@
 mango.util package
 ==================
 
-Submodules
-----------
-
 mango.util.clock module
 -----------------------
 
@@ -40,14 +37,6 @@ mango.util.termination\_detection module
 ----------------------------------------
 
 .. automodule:: mango.util.termination_detection
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: mango.util
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,28 +4,14 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
-import sys
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../../mango"))
-
 # -- Project information -----------------------------------------------------
 
 project = "mango"
-copyright = "2023, mango team"
+copyright = "2024, mango team"
 author = "mango team"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1"
+version = release = "1.1.4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,13 +1,13 @@
-========
+===============
 Getting started
-========
+===============
 In this section you will get to know the necessary steps to create a simple multi-agent system
 using *mango*. For an introduction to the different features that mango offers, we refer to the
 :doc:`tutorial`.
 
-***************
+*****************
 Creating an agent
-***************
+*****************
 In our first example, we create a very simple agent that simply prints the content of
 all messages it receives:
 
@@ -30,9 +30,9 @@ Agents must be a subclass of :class:`Agent`. This base class needs
 a reference to the container that the agents live in, so you must forward
 a *container* argument to it if you override ``__init__()``.
 
-***************
+********************
 Creating a container
-***************
+********************
 
 Agents live in a container, so we need to know how to create a mango container.
 The container is responsible for message exchange between agents. More information about container and agents can be
@@ -52,9 +52,9 @@ coroutine__ we need to await its result.
 
 __ https://docs.python.org/3.10/library/asyncio-task.html
 
-***************
+*******************************************
 Running your first agent within a container
-***************
+*******************************************
 To put it all together we will wrap the creation of a container and the agent into a coroutine
 and execute it using :py:meth:`asyncio.run()`.
 The following script will create a RepeatingAgent
@@ -91,9 +91,9 @@ then shutdown the container:
 The only output you should see is "Hello world! My id is agent0.", because
 the agent does not receive any other messages.
 
-***************
+**************************
 Creating a proactive Agent
-***************
+**************************
 
 Let's implement another agent that is able to send a hello world message
 to another agent:
@@ -116,9 +116,9 @@ to another agent:
 
 We are using the scheduling API, which is explained in further detail in the section :doc:`scheduling`.
 
-***************
+*********************
 Connecting two agents
-***************
+*********************
 We can now connect an instance of a HelloWorldAgent with an instance of
 a RepeatingAgent and let them run.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,6 @@ Features
    agents-container
    message exchange
    scheduling
-   ACL messages
    codecs
    role-api
    development

--- a/docs/source/message exchange.rst
+++ b/docs/source/message exchange.rst
@@ -1,10 +1,10 @@
-========
+================
 Message exchange
-========
+================
 
-***************
+******************
 Receiving messages
-***************
+******************
 Custom agents that inherit from the ``Agent`` class are able to receive messages from
 other agents via the method ``handle_message``.
 Hence this method has to be overwritten. The structure of this method looks like this:
@@ -43,9 +43,9 @@ A simple agent, that just prints the content and meta information of incoming me
                 f'meta {meta}')
 
 
-***************
+****************
 Sending messages
-***************
+****************
 
 Agents are able to send messages to other agents via the container method send_message:
 

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -1,5 +1,5 @@
 Migration
-========
+=========
 
 Some mango versions will break the API; in this case, we may provide instructions on the migration on this page.
 

--- a/mango/agent/role.py
+++ b/mango/agent/role.py
@@ -7,10 +7,9 @@ monitoring grid voltage another one.
 A role is part of a :class:`RoleAgent` which inherits from :class:`Agent`.
 
 There are essentially two APIs for acting resp reacting:
-* [Reacting] :func:`RoleContext.subscribe_message`, which allows you to subscribe to
-             certain message types and lets you handle the message
-* [Acting] :func:`RoleContext.schedule_task`, this allows you to schedule a task with
-            delay/repeating/...
+
+* [Reacting] :func:`RoleContext.subscribe_message`, which allows you to subscribe to certain message types and lets you handle the message
+* [Acting] :func:`RoleContext.schedule_task`, this allows you to schedule a task with delay/repeating/...
 
 To interact with the environment an instance of the role context is provided. This context
 provides methods to share data with other roles and to communicate with other agents.
@@ -27,6 +26,7 @@ To set this up, a model has to be created via
 If you prefer a lightweight variant you can use :func:`RoleContext.data` to assign/access shared data.
 
 Furthermore there are two lifecycle methods to know about:
+
 * :func:`Role.setup` is called when the Role is added to the agent, so its the perfect place
                      for initialization and scheduling of tasks
 * :func:`Role.on_stop` is called when the container the agent lives in, is shut down
@@ -71,6 +71,7 @@ class Role(ABC):
 
     Every role
     must be added to a :class:`RoleAgent` and is defined by some lifecycle methods:
+
     * :func:`Role.setup` is called when the Role is added to the agent, so its the perfect place for
                          initialization and scheduling of tasks
     * :func:`Role.on_stop` is called when the container the agent lives in, is shut down
@@ -228,9 +229,12 @@ class RoleHandler:
 
     def handle_message(self, content, meta: Dict[str, Any]):
         """Handle an incoming message, delegating it to all applicable subscribers
-        for role, message_condition, method, _ in self._message_subs:
-            if self._is_role_active(role) and message_condition(content, meta):
-                method(content, meta)
+
+        .. code-block:: python
+
+            for role, message_condition, method, _ in self._message_subs:
+                if self._is_role_active(role) and message_condition(content, meta):
+                    method(content, meta)
 
         :param content: content
         :param meta: meta
@@ -392,9 +396,12 @@ class RoleContext(AgentDelegates):
 
     def handle_message(self, content, meta: Dict[str, Any]):
         """Handle an incoming message, delegating it to all applicable subscribers
-        for role, message_condition, method, _ in self._message_subs:
-            if self._is_role_active(role) and message_condition(content, meta):
-                method(content, meta)
+
+        .. code-block:: python
+
+            for role, message_condition, method, _ in self._message_subs:
+                if self._is_role_active(role) and message_condition(content, meta):
+                    method(content, meta)
 
         :param content: content
         :param meta: meta

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -84,9 +84,10 @@ def create_agent_process_environment(
     """Create the agent process environment for using agent subprocesses
     in a mango container. This routine will create a new event loop and run
     the so-called agent-loop, which will
+
     1. initialize the mirror-container and the agents
     2. will wait and return to the event loop until there is a terminate signal
-      * while this step, the container and its agents are responsive
+        * while this step, the container and its agents are responsive
     3. shutdown the mirror container
 
     :param container_data: data for the mirror container creation
@@ -166,7 +167,7 @@ class BaseContainerProcessManager:
         :param receiver_id: aid of the receiver
         :type receiver_id: str
         :param priority: prio
-        :type priority: int_
+        :type priority: int
         :param meta: meta
         :type meta: dict
         :raises NotImplementedError: generally not implemented in mirror container manager
@@ -182,12 +183,12 @@ class BaseContainerProcessManager:
         original container for all agents which live in its process.
 
         :param agent_creator: function with one argument 'container', which creates all agents, which
-        shall live in the process
+            shall live in the process
         :type agent_creator: Function(Container)
         :param container: the main container
         :type container: Container
         :param mirror_container_creator: function, which creates a mirror container, given container
-        data and IPC connection data
+            data and IPC connection data
         :type mirror_container_creator: Function(ContainerData, AsyncioLoop, AioDuplex, AioDuplex, Event)
         :raises NotImplementedError: generally raised if the manager is a mirror manager
         """
@@ -209,8 +210,8 @@ class BaseContainerProcessManager:
         :param default_meta: meta
         :type default_meta: dict
         :return: Tuple, first the status (True, False = successful, unsuccessful and prevent
-        the original send_internal_message, None = Continue original call), second the Queue-like
-        inbox, in which the message should be redirected in
+            the original send_internal_message, None = Continue original call), second the Queue-like
+            inbox, in which the message should be redirected in
         :rtype: Tuple[Boolean, Queue-like]
         """
         return None, None
@@ -227,7 +228,7 @@ class BaseContainerProcessManager:
         return None
 
     def dispatch_to_agent_process(self, pid: int, coro_func, *args):
-        """Dispatches a coroutine function to another process. The coroutine_func
+        """Dispatches a coroutine function to another process. The `coroutine_func`
         and its arguments are serialized and sent to the agent process, in which it
         is executed with the Container as first argument (followed by the defined arguments).
 
@@ -609,9 +610,11 @@ class Container(ABC):
     def register_agent(self, agent, suggested_aid: str = None):
         """
         Register *agent* and return the agent id
+
         :param agent: The agent instance
         :param suggested_aid: (Optional) suggested aid, if the aid is already taken, a generated aid is used.
-                              Using the generated aid-style ("agentX") is not allowed.
+            Using the generated aid-style ("agentX") is not allowed.
+
         :return The agent ID
         """
         if not self._no_agents_running or self._no_agents_running.done():
@@ -624,9 +627,9 @@ class Container(ABC):
     def deregister_agent(self, aid):
         """
         Deregister an agent
+
         :param aid:
         :return:
-
         """
         del self._agents[aid]
         if len(self._agents) == 0:
@@ -667,7 +670,7 @@ class Container(ABC):
 
         :param content: The content of the message
         :param receiver_addr: In case of TCP this is a tuple of host, port
-        In case of MQTT this is the topic to publish to.
+            In case of MQTT this is the topic to publish to.
         :param receiver_id: The agent id of the receiver
         :param acl_metadata: metadata for the acl_header.
         :param is_anonymous_acl: If set to True, the sender information won't be written in the ACL header
@@ -831,7 +834,7 @@ class Container(ABC):
 
     def as_agent_process(self, agent_creator, mirror_container_creator):
         """Spawn a new process with a container, mirroring the current container, and
-        1 to n agents, created by 'agent_creator'. Can be used to introduce real
+        1 to n agents, created by `agent_creator`. Can be used to introduce real
         parallelization using the agents as unit to divide.
 
         Internally this will create a process with its own asyncio loop and an own
@@ -840,13 +843,13 @@ class Container(ABC):
         it would in the parent process and in the main container (this).
 
         :param agent_creator: function, which creates 1...n agents, has exactly one argument
-        the mirror container
+            the mirror container
         :type agent_creator: Function(Container)
         :param mirror_container_creator: function, which creates the mirror container, generally
-        this parameter is set by the subclasses of container
+            this parameter is set by the subclasses of container
         :type mirror_container_creator: Function(ContainerData, AsyncioLoop, AioDuplex, AioDuplex, Event)
         :return: a handle for the created process. It contains the pid as property 'pid' and can be awaited
-        to make sure the initialization of the agents in the subprocess is actually done.
+            to make sure the initialization of the agents in the subprocess is actually done.
         :rtype: AgentProcessHandle
         """
         return self._container_process_manager.create_agent_process(
@@ -859,12 +862,12 @@ class Container(ABC):
         """Dispatch a coroutine function and its necessary arguments to the process 'pid'.
         This allows the user to execute arbitrary code in the agent subprocesses.
 
-        The coro_func accepts coro_func(Container, *args).
+        The ``coro_func`` accepts ``coro_func(Container, *args)``.
 
         :param pid: the pid in which the coro func should get dispatched
         :type pid: int
-        :param coro_func: async function(Container, *args)
-        :type coro_func: async function(Container, *args)
+        :param coro_func: async function(Container, ...)
+        :type coro_func: async function(Container, ...)
         """
         self._container_process_manager.dispatch_to_agent_process(pid, coro_func, *args)
 

--- a/mango/container/factory.py
+++ b/mango/container/factory.py
@@ -34,17 +34,19 @@ async def create(
     This method is called to instantiate a container instance, either
     a TCPContainer or a MQTTContainer, depending on the parameter
     connection_type.
+
     :param connection_type: Defines the connection type. So far only 'tcp'
-    or 'mqtt' are allowed
+        or 'mqtt' are allowed
     :param codec: Defines the codec to use. Defaults to JSON
     :param clock: The clock that the scheduler of the agent should be based on. Defaults to the AsyncioClock
     :param addr: the address to use. If connection_type == 'tcp': it has
-    to be a tuple of (host, port). If connection_type == 'mqtt' this can
-    optionally define an inbox_topic that is used similarly than
-    a tcp address.
+        to be a tuple of (host, port). If connection_type == 'mqtt' this can
+        optionally define an inbox_topic that is used similarly than
+        a tcp address.
     :param mqtt_kwargs: Dictionary of keyword arguments for connection to a mqtt broker. At least
-    the keys 'broker_addr' and 'client_id' have to be provided.
-    Ignored if connection_type != 'mqtt'
+        the keys 'broker_addr' and 'client_id' have to be provided.
+        Ignored if connection_type != 'mqtt'
+
     :return: The instance of a MQTTContainer or a TCPContainer
     """
     connection_type = connection_type.lower()

--- a/mango/messages/codecs.py
+++ b/mango/messages/codecs.py
@@ -3,7 +3,7 @@ This package imports the codecs that can be used for de- and encoding incoming
 and outgoing messages:
 
 - :class:`JSON` uses `JSON <http://www.json.org/>`_
-- :class:`protobuf' uses protobuf
+- :class:`protobuf` uses protobuf
 
 All codecs should implement the base class :class:`Codec`.
 

--- a/mango/modules/base_module.py
+++ b/mango/modules/base_module.py
@@ -11,8 +11,8 @@ from .zero_module import ZeroModule
 class BaseModule:
     """An agent can have multiple specialized modules which inherit
     from BaseModule. The all need to specify which messaging framework should
-     be used for the internal message exchange between the modules.
-     TODO write more
+    be used for the internal message exchange between the modules.
+    TODO write more
     """
 
     frameworks = {"mqtt": MQTTModule, "rabbit": RabbitModule, "zero": ZeroModule}
@@ -22,6 +22,7 @@ class BaseModule:
     ):
         """
         Initialization of the module
+
         :param name: name of the module (str)
         :param subscr_topics: List of string and integer tuples for subscribed
          topics:[ (topic, qos)] e.g.[("my/topic", 0), ("another/topic", 2)]

--- a/mango/modules/mqtt_module.py
+++ b/mango/modules/mqtt_module.py
@@ -76,10 +76,12 @@ class MQTTModule:
         Function to call our generic callback function that has only two
         parameters from the framework specific callback with four parameters by
         binding it as a partial function.
+
         :param func: The wanted callback function
         :param client: the messaging client (unused)
         :param userdata: the userdata object (unused)
         :param message: the message payload
+
         :return: None
         """
         func(topic=message.topic, payload=message.payload)
@@ -88,11 +90,13 @@ class MQTTModule:
         # pylint: disable=unused-argument
         """
         Callback method on broker connection on paho mqtt framework
+
         :param client: the connecting client
         :param userdata: userdata object
         :param flags: returned flags
         :param reason_code: reason code
         :param properties: properties
+
         :return: None
         """
 
@@ -102,10 +106,12 @@ class MQTTModule:
         # pylint: disable=unused-argument
         """
         Callback method on broker disconnect on paho mqtt framework
+
         :param client: the connecting client
         :param userdata: userdata object
         :param reason_code: reason code
         :param properties: properties
+
         :return: None
         """
 
@@ -113,10 +119,12 @@ class MQTTModule:
         # pylint: disable=unused-argument
         """
         Client log method
+
         :param client: the mqtt client
         :param userdata: userdata object
         :param level: log level
         :param buf: data buffer
+
         :return: None
         """
 
@@ -124,8 +132,10 @@ class MQTTModule:
         """
         Each module has to implement this to handle all messages it receives
          in subscribed topics
+
         :param client:
         :param userdata:
         :param message:
+
         :return:
         """

--- a/mango/util/multiprocessing.py
+++ b/mango/util/multiprocessing.py
@@ -6,13 +6,15 @@ these pipes, use aiopipe() or aioduplex(). The idea of the code is based on the 
 
 These pipes provide async compatible APIs, here a general example:
 
-main, sub = aioduplex()
-with sub.detach() as sub:
-    # start your process with sub as inherited pipe
-async with main.open() as (rx, tx):
-    item = await rx.read_object()
-    tx.write_object()
-    ...
+.. code-block:: python
+
+    main, sub = aioduplex()
+    with sub.detach() as sub:
+        # start your process with sub as inherited pipe
+    async with main.open() as (rx, tx):
+        item = await rx.read_object()
+        tx.write_object()
+        ...
 
 Further there are internal connection objects, which can be used if a synchronous access outside of the
 asyncio loop is necessary: 'main.write_connection, main.read_connection'. Note, that you can't use


### PR DESCRIPTION
There were a lot of warning in sphinx

* the sphinx python version was 3.7, so I increased that to 3.12
* fixed docs warnings
* update conf.py
* add pika and pyzmq to requirements for module docs

Usage:

`make -C docs html`
and to view it use
`python -m http.server --directory docs/build/html`


There is a check in the readthedocs interface to activate building for pull-requests, which is quite neat @rcschrg 