### PR TITLE
mark tests with mqtt

### DIFF
--- a/tests/integration_tests/test_single_container_termination.py
+++ b/tests/integration_tests/test_single_container_termination.py
@@ -176,6 +176,7 @@ async def test_distribute_ping_pong_tcp():
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_distribute_ping_pong_mqtt():
     await distribute_ping_pong_test("mqtt")
 
@@ -186,6 +187,7 @@ async def test_distribute_ping_pong_ts_tcp():
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_distribute_ping_pong_ts_mqtt():
     await distribute_ping_pong_test_timestamp("mqtt")
 
@@ -296,6 +298,7 @@ async def test_distribute_time_tcp():
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_distribute_time_mqtt():
     await distribute_time_test_case("mqtt")
 
@@ -306,5 +309,6 @@ async def test_send_current_time_tcp():
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_send_current_time_mqtt():
     await send_current_time_test_case("mqtt")

--- a/tests/unit_tests/express/test_api.py
+++ b/tests/unit_tests/express/test_api.py
@@ -119,6 +119,7 @@ async def test_run_api_style_agent_with_aid():
 
 
 @pytest.mark.asyncio
+@pytest.mark.mqtt
 async def test_run_api_style_agent_with_aid_mqtt():
     # GIVEN
     run_agent = MyAgent()


### PR DESCRIPTION
makes it possible to run all other tests using `pytest -m "not mqtt"` without having a mqtt broker running