### PR TITLE
remove overloaded property functions in RoleContext

### DIFF
--- a/mango/agent/role.py
+++ b/mango/agent/role.py
@@ -362,14 +362,6 @@ class RoleContext(AgentDelegates):
         """
         self._role_handler.subscribe_event(role, event_type, handler_method)
 
-    @property
-    def addr(self):
-        return self._agent_context.addr
-
-    @property
-    def aid(self):
-        return self._aid
-
     def deactivate(self, role) -> None:
         self._role_handler.deactivate(role)
 


### PR DESCRIPTION
These functions were not used in Roles until now, so we do not need to adjust anything else.

closes #111