### PR TITLE
allow initialization of agents without a running event loop

### DIFF
--- a/mango/agent/core.py
+++ b/mango/agent/core.py
@@ -420,7 +420,7 @@ class Agent(ABC, AgentDelegates):
         """
 
     def _do_register(self, container, aid):
-        self._check_inbox_task = asyncio.create_task(self._check_inbox())
+        self._check_inbox_task = container._loop.create_task(self._check_inbox())
         self._check_inbox_task.add_done_callback(self._raise_exceptions)
         self._stopped = asyncio.Future()
         self._aid = aid

--- a/mango/container/external_coupling.py
+++ b/mango/container/external_coupling.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 from dataclasses import dataclass
@@ -76,6 +77,7 @@ class ExternalSchedulingContainer(Container):
             **kwargs,
         )
 
+        self._loop = asyncio.get_event_loop()
         self.running = True
         self.current_start_time_of_step = time.time()
         self._new_internal_message: bool = False

--- a/mango/container/mqtt.py
+++ b/mango/container/mqtt.py
@@ -81,6 +81,7 @@ class MQTTContainer(Container):
         )
 
         self.client_id: str = client_id
+        self._loop = asyncio.get_event_loop()
         # the client will be created on start.
         self.mqtt_client: paho.Client = None
         self.inbox_topic: None | str = inbox_topic
@@ -90,7 +91,6 @@ class MQTTContainer(Container):
         self.pending_sub_request: None | asyncio.Future = None
 
     async def start(self):
-        self._loop = asyncio.get_event_loop()
         if not self.client_id:
             raise ValueError("client_id is required!")
         if not self.addr:

--- a/mango/container/tcp.py
+++ b/mango/container/tcp.py
@@ -183,6 +183,7 @@ class TCPContainer(Container):
         self._tcp_connection_pool = None
         self.server = None  # will be set within start
         self.running = False
+        self._loop = asyncio.get_event_loop()
         self._tcp_connection_pool = TCPConnectionPool(
             ttl_in_sec=self._kwargs.get(TCP_CONNECTION_TTL, 30),
             max_connections_per_target=self._kwargs.get(
@@ -193,7 +194,7 @@ class TCPContainer(Container):
     async def start(self):
         # create a TCP server bound to host and port that uses the
         # specified protocol
-        self.server = await asyncio.get_running_loop().create_server(
+        self.server = await self._loop.create_server(
             lambda: ContainerProtocol(container=self, codec=self.codec),
             self.addr[0],
             self.addr[1],

--- a/tests/unit_tests/core/test_agent.py
+++ b/tests/unit_tests/core/test_agent.py
@@ -102,3 +102,10 @@ async def test_schedule_acl_message():
 
     # THEN
     assert agent2.test_counter == 1
+
+
+def test_sync_setup_agent():
+    # this test is not async and therefore does not provide a running event loop
+    c = create_tcp_container(addr=("127.0.0.1", 5555))
+    agent = c.register(MyAgent())
+    # registration without async context should not raise "no running event loop" error


### PR DESCRIPTION
Before, we received the error "no running event loop" when attaching an agent outside of an async context.

We solve this by assigning an event loop to all container types, making it possible to create agents in a sync setting where no event loop is running (yet).
The solution is to attach the inbox task to a precreated asyncio.loop which is used later on.

Eventually, there is a smarter way to do this.
Evenetually we should let the MQTT server have a second loop which is independent of ours?

(Note: this PR goes into feature-topology for now for better readability)