### PR TITLE
raise exception when trying to register a container which is already registered

### DIFF
--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -118,6 +118,8 @@ class Container(ABC):
         :return The agent ID
         """
         aid = self._reserve_aid(suggested_aid)
+        if agent.context:
+            raise ValueError("Agent is already registered to a container")
         self._agents[aid] = agent
         agent._do_register(self, aid)
         logger.debug("Successfully registered agent;%s", aid)

--- a/tests/unit_tests/core/test_agent.py
+++ b/tests/unit_tests/core/test_agent.py
@@ -102,3 +102,11 @@ async def test_schedule_acl_message():
 
     # THEN
     assert agent2.test_counter == 1
+
+def test_register_twice():
+    c = create_tcp_container(addr=("127.0.0.1", 5555))
+    agent = MyAgent()
+    c.register(agent)
+
+    with pytest.raises(ValueError):
+        c.register(agent)


### PR DESCRIPTION
This makes sure that an accidental second register call fails early - otherwise one would get a CancelledError at the end of the simulation.

There probably is a better way to solve this, as my current approach does not allow to register an agent, deregister it and register it to a different agent, though this is probably never needed.

So this problem is rather low prio..