### PR TITLE
allows ordering AgentAddresses

### DIFF
--- a/mango/agent/core.py
+++ b/mango/agent/core.py
@@ -18,7 +18,7 @@ from ..util.scheduling import ScheduledProcessTask, ScheduledTask, Scheduler
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class AgentAddress:
     protocol_addr: Any
     aid: str

--- a/tests/unit_tests/core/test_agent.py
+++ b/tests/unit_tests/core/test_agent.py
@@ -102,6 +102,7 @@ async def test_schedule_acl_message():
     # THEN
     assert agent2.test_counter == 1
 
+
 def test_register_twice():
     c = create_tcp_container(addr=("127.0.0.1", 5555))
     agent = MyAgent()
@@ -109,6 +110,7 @@ def test_register_twice():
 
     with pytest.raises(ValueError):
         c.register(agent)
+
 
 def test_sync_setup_agent():
     # this test is not async and therefore does not provide a running event loop

--- a/tests/unit_tests/core/test_container.py
+++ b/tests/unit_tests/core/test_container.py
@@ -5,6 +5,8 @@ from mango.agent.core import Agent, AgentAddress
 
 
 class LooksLikeAgent:
+    context = None
+
     async def shutdown(self):
         pass
 
@@ -263,3 +265,22 @@ async def test_auto_port_container():
         pass
 
     assert c1.addr[1] is not None
+
+
+def test_agent_address_sortable():
+    a1 = AgentAddress(("127.0.0.1", 5555), "aid1")
+    a2 = AgentAddress(("127.0.0.1", 5555), "aid2")
+
+    # generally allow sorting AgentAddresses
+    assert a1 < a2
+
+    # known caveat: same address is not resolved
+    a10 = AgentAddress(("127.0.0.1", 5555), "aid10")
+    a1_local = AgentAddress(("localhost", 5555), "aid1")
+    assert a1 != a1_local
+
+    # container takes precedence over agent_id
+    assert a2 < a1_local
+
+    # sorting is alphanumically
+    assert a10 < a2


### PR DESCRIPTION
I had the issue, that I ordered the AgentAddress tuples just fine in mango 1.x to create reproducibility.

This was missing in the AgentAddress, but is added through `order=True` in the dataclass.
This does not bring any harm and allows for comparison of AgentAddresses.

I also fixed the ruff linting which failed in the dev branch and added an empty context for the tests to succeed