### PR TITLE
add create_acl_with_sender syntax sugar

### DIFF
--- a/mango/__init__.py
+++ b/mango/__init__.py
@@ -1,4 +1,4 @@
-from .messages.message import create_acl, Performatives
+from .messages.message import create_acl, create_acl_with_sender, Performatives
 from .agent.core import Agent, AgentAddress
 from .agent.role import Role, RoleAgent, RoleContext
 from .container.factory import (

--- a/mango/messages/message.py
+++ b/mango/messages/message.py
@@ -305,3 +305,36 @@ def create_acl(
     for key, value in acl_metadata.items():
         setattr(message, key, value)
     return message
+
+
+def create_acl_with_sender(
+    content,
+    receiver_addr: AgentAddress,
+    sender_addr: AgentAddress,
+    acl_metadata: None | dict[str, Any] = None,
+    is_anonymous_acl=False,
+):
+    """
+    create_acl function, which does not require to pass the receiver_addr twice
+
+    self.context.send_message(
+        **create_acl_with_sender(
+            "message content",
+            receiver_addr,
+            self.context.addr,
+            acl_metadata={
+                "in_reply_to": "reply_to",
+            },
+        )
+    )
+    """
+    return {
+        "content": create_acl(
+            content,
+            receiver_addr,
+            sender_addr,
+            acl_metadata,
+            is_anonymous_acl,
+        ),
+        "receiver_addr": receiver_addr,
+    }


### PR DESCRIPTION
this function can be passed as a dict to the send_message, sparing a second receiver_addr argument

I wonder what you think about this, but it adds a lot of comfort instead of having to write the receiver_addr twice.

This would need more documentation and a test or two though.