### PR TITLE
add delayed container start

### DIFF
--- a/docs/source/agents-container.rst
+++ b/docs/source/agents-container.rst
@@ -87,7 +87,7 @@ user to worry about it. This will also shutdown all agents that are still runnin
 ***************
 mango agents
 ***************
-mango agents can be implemented by inheriting from the abstract class ``mango.Agent``.
+mango agents can be implemented by inheriting from the abstract class :meth:`mango.Agent`.
 This class provides basic functionality such as to scheduling convenience methods or to constantly check the inbox for incoming messages.
 Every agent can live in exactly one container, to register an agent the method :meth:`mango.Container.register` can be used. This method will assign
 the agent a generated agent id (aid) and enables the agent scheduling feature.
@@ -177,7 +177,7 @@ The ``process_handle`` is awaitable and will finish exactly when the process is 
 
 Note that after the creation, the agent lives in a mirror container in another process. Therefore, it is not possible to interact
 with the agent directly from the main process. If you want to interact with the agent after the creation, it is possible to
-dispatch a task in the agent process using `dispatch_to_agent_process`.
+dispatch a task in the agent process using :meth:`mango.container.core.Container.dispatch_to_agent_process`.
 
 .. code-block:: python3
 
@@ -186,3 +186,7 @@ dispatch a task in the agent process using `dispatch_to_agent_process`.
         your_function, # will be called with the mirror container + varargs as arguments
         ... # varargs, additional arguments you want to pass to your_function
     )
+
+To also be able to use this feature when setting up agents without a running asyncio loop, you can use the :meth:`mango.container.core.Container.as_agent_process_lazy` function.
+This function does not have a return value and therefore does not enable access to the process handle.
+When the container is activated (and thus, an asyncio context exists), the mirror containers are created.

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -298,6 +298,8 @@ class Container(ABC):
         # task that processes the inbox.
         self._check_inbox_task: asyncio.Task = asyncio.create_task(self._check_inbox())
 
+        await self._container_process_manager.start()
+
         """Start the container. It totally depends on the implementation for what is actually happening."""
         for agent in self._agents.values():
             agent._do_start()

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -251,7 +251,11 @@ class Container(ABC):
                 content, receiver_id, priority, meta
             )
 
-    def as_agent_process(self, agent_creator, mirror_container_creator):
+    def _create_mirror_container(self):
+        """Returns the Container specific creation function for a new mirror container"""
+        raise NotImplementedError
+
+    async def as_agent_process(self, agent_creator, mirror_container_creator=None):
         """Spawn a new process with a container, mirroring the current container, and
         1 to n agents, created by `agent_creator`. Can be used to introduce real
         parallelization using the agents as unit to divide.
@@ -271,7 +275,22 @@ class Container(ABC):
             to make sure the initialization of the agents in the subprocess is actually done.
         :rtype: AgentProcessHandle
         """
-        return self._container_process_manager.create_agent_process(
+        if not mirror_container_creator:
+            mirror_container_creator = self._create_mirror_container()
+        return await self._container_process_manager.create_agent_process(
+            agent_creator=agent_creator,
+            container=self,
+            mirror_container_creator=mirror_container_creator,
+        )
+
+    def as_agent_process_lazy(self, agent_creator, mirror_container_creator=None):
+        """
+        Similar to as_agent_process, but does not wait for the agent process to be initialized.
+        Does also not need a running event loop, making it suitable to add agent processes without an asyncio context.
+        """
+        if not mirror_container_creator:
+            mirror_container_creator = self._create_mirror_container()
+        self._container_process_manager.create_agent_process_lazy(
             agent_creator=agent_creator,
             container=self,
             mirror_container_creator=mirror_container_creator,

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -99,7 +99,8 @@ class Container(ABC):
                 return suggested_aid
             else:
                 logger.warning(
-                    "The suggested aid could not be reserved, either it is not available or it is not allowed (pattern agentX);%s",
+                    "The suggested aid could not be reserved, either it is not available or it is not allowed (pattern %sX);%s",
+                    AGENT_PATTERN_NAME_PRE,
                     suggested_aid,
                 )
 

--- a/mango/container/external_coupling.py
+++ b/mango/container/external_coupling.py
@@ -182,12 +182,5 @@ class ExternalSchedulingContainer(Container):
             next_activity=self.clock.get_next_activity(),
         )
 
-    def as_agent_process(
-        self,
-        agent_creator,
-        mirror_container_creator=ext_mirror_container_creator,
-    ):
-        return super().as_agent_process(
-            agent_creator=agent_creator,
-            mirror_container_creator=mirror_container_creator,
-        )
+    def _create_mirror_container(self):
+        return ext_mirror_container_creator

--- a/mango/container/mp.py
+++ b/mango/container/mp.py
@@ -125,7 +125,10 @@ def create_agent_process_environment(
 
         for agent in container._agents.values():
             agent._do_start()
+
         container.running = True
+        container.on_ready()
+
         while not terminate_event.is_set():
             await asyncio.sleep(WAIT_STEP)
         await container.shutdown()

--- a/mango/container/mqtt.py
+++ b/mango/container/mqtt.py
@@ -453,20 +453,11 @@ class MQTTContainer(Container):
             self.additional_subscriptions.pop(subscription)
             self.mqtt_client.unsubscribe(topic=subscription)
 
-    def as_agent_process(
-        self,
-        agent_creator,
-        mirror_container_creator=None,
-    ):
-        if not mirror_container_creator:
-            mirror_container_creator = partial(
-                mqtt_mirror_container_creator,
-                self.client_id,
-                self.inbox_topic,
-            )
-        return super().as_agent_process(
-            agent_creator=agent_creator,
-            mirror_container_creator=mirror_container_creator,
+    def _create_mirror_container(self):
+        return partial(
+            mqtt_mirror_container_creator,
+            self.client_id,
+            self.inbox_topic,
         )
 
     async def shutdown(self):

--- a/mango/container/tcp.py
+++ b/mango/container/tcp.py
@@ -223,7 +223,11 @@ class TCPContainer(Container):
         elif isinstance(protocol_addr, tuple | list) and len(protocol_addr) == 2:
             protocol_addr = tuple(protocol_addr)
         else:
-            logger.warning("Address for sending message is not valid;%s", protocol_addr)
+            logger.warning(
+                "Receiver ProtocolAddress sending message from %s to %s is not valid",
+                sender_id,
+                receiver_addr,
+            )
             return False
 
         meta = {}

--- a/mango/container/tcp.py
+++ b/mango/container/tcp.py
@@ -291,6 +291,9 @@ class TCPContainer(Container):
             return False
         return True
 
+    def _create_mirror_container(self):
+        return tcp_mirror_container_creator
+
     def as_agent_process(
         self,
         agent_creator,

--- a/mango/util/termination_detection.py
+++ b/mango/util/termination_detection.py
@@ -22,7 +22,9 @@ def unfinished_task_count(container: Container):
 async def tasks_complete_or_sleeping(container: Container, except_sources=["no_wait"]):
     sleeping_tasks = []
     task_list = []
-    await container.inbox.join()
+    # is None for containers in MirrorContainerProcessManager
+    if container.inbox is not None:
+        await container.inbox.join()
     # python does not have do while pattern
     for agent in container._agents.values():
         await agent.inbox.join()
@@ -33,7 +35,8 @@ async def tasks_complete_or_sleeping(container: Container, except_sources=["no_w
     while len(task_list) > len(sleeping_tasks):
         # sleep needed so that asyncio tasks of this time step are correctly awaken.
         # await asyncio.sleep(0)
-        await container.inbox.join()
+        if container.inbox is not None:
+            await container.inbox.join()
         for scheduled_task, task, _, _ in task_list:
             await asyncio.wait(
                 [scheduled_task._is_sleeping, scheduled_task._is_done],

--- a/tests/integration_tests/test_message_roundtrip_mp.py
+++ b/tests/integration_tests/test_message_roundtrip_mp.py
@@ -35,10 +35,10 @@ async def test_mp_simple_ping_pong_multi_container_tcp():
     container_2 = create_tcp_container(
         addr=repl_addr,
     )
-    await container_1.as_agent_process(
+    container_1.as_agent_process(
         agent_creator=lambda c: c.register(PingPongAgent(), suggested_aid=aid1)
     )
-    await container_2.as_agent_process(
+    container_2.as_agent_process(
         agent_creator=lambda c: c.register(PingPongAgent(), suggested_aid=aid2)
     )
     agent = container_1.register(PingPongAgent())

--- a/tests/integration_tests/test_message_roundtrip_mp.py
+++ b/tests/integration_tests/test_message_roundtrip_mp.py
@@ -35,10 +35,10 @@ async def test_mp_simple_ping_pong_multi_container_tcp():
     container_2 = create_tcp_container(
         addr=repl_addr,
     )
-    container_1.as_agent_process(
+    await container_1.as_agent_process(
         agent_creator=lambda c: c.register(PingPongAgent(), suggested_aid=aid1)
     )
-    container_2.as_agent_process(
+    await container_2.as_agent_process(
         agent_creator=lambda c: c.register(PingPongAgent(), suggested_aid=aid2)
     )
     agent = container_1.register(PingPongAgent())

--- a/tests/unit_tests/container/test_mp.py
+++ b/tests/unit_tests/container/test_mp.py
@@ -63,7 +63,7 @@ async def test_agent_processes_ping_pong(num_sp_agents, num_sp):
     # GIVEN
     c = create_tcp_container(addr=("127.0.0.1", 15589), copy_internal_messages=False)
     for i in range(num_sp):
-        await c.as_agent_process(
+        c.as_agent_process(
             agent_creator=lambda container: [
                 container.register(MyAgent(), suggested_aid=f"process_agent{i},{j}")
                 for j in range(num_sp_agents)
@@ -151,5 +151,17 @@ async def test_async_agent_processes_ping_pong_p_to_p():
     assert main_agent.test_counter == 2
 
 
+def test_sync_setup_agent_processes():
+    # GIVEN
+    c = create_tcp_container(addr=("127.0.0.1", 15589), copy_internal_messages=False)
+    c.as_agent_process(
+        agent_creator=lambda container: [
+            container.register(MyAgent(), suggested_aid="process_agent0")
+        ]
+    )
+    agent = c.register(MyAgent())
+
 if __name__ == "__main__":
     asyncio.run(test_agent_processes_ping_pong(5, 5))
+
+

--- a/tests/unit_tests/container/test_mp.py
+++ b/tests/unit_tests/container/test_mp.py
@@ -91,7 +91,7 @@ async def test_agent_processes_ping_pong_p_to_p():
     addr = ("127.0.0.1", 5829)
     aid_main_agent = "main_agent"
     c = create_tcp_container(addr=addr, copy_internal_messages=False)
-    await c.as_agent_process(
+    c.as_agent_process(
         agent_creator=lambda container: container.register(
             P2PTestAgent(aid_main_agent), suggested_aid="process_agent1"
         )
@@ -108,7 +108,7 @@ async def test_agent_processes_ping_pong_p_to_p():
         return agent
 
     async with activate(c) as c:
-        await c.as_agent_process(agent_creator=agent_init)
+        c.as_agent_process(agent_creator=agent_init)
 
         while main_agent.test_counter != 1:
             await asyncio.sleep(0.1)
@@ -133,7 +133,7 @@ async def test_async_agent_processes_ping_pong_p_to_p():
         await p2pta.send_message(content="pong", receiver_addr=target_addr)
 
     async with activate(c) as c:
-        await c.as_agent_process(agent_creator=agent_creator)
+        c.as_agent_process(agent_creator=agent_creator)
 
         # WHEN
         def agent_init(c):
@@ -143,7 +143,7 @@ async def test_async_agent_processes_ping_pong_p_to_p():
             )
             return agent
 
-        await c.as_agent_process(agent_creator=agent_init)
+        c.as_agent_process(agent_creator=agent_init)
 
         while main_agent.test_counter != 2:
             await asyncio.sleep(0.1)
@@ -161,7 +161,6 @@ def test_sync_setup_agent_processes():
     )
     agent = c.register(MyAgent())
 
+
 if __name__ == "__main__":
     asyncio.run(test_agent_processes_ping_pong(5, 5))
-
-

--- a/tests/unit_tests/core/test_agent.py
+++ b/tests/unit_tests/core/test_agent.py
@@ -112,7 +112,7 @@ def test_register_twice():
         c.register(agent)
 
 
-def test_sync_setup_agent():
+def test_lazy_setup_agent():
     # this test is not async and therefore does not provide a running event loop
     c = create_tcp_container(addr=("127.0.0.1", 5555))
     # registration without async context should not raise "no running event loop" error


### PR DESCRIPTION
This  solves having sync creation of `as_agent_process`.

fixes #129

This is based on top of the described wanted behavior in: https://github.com/maurerle/mango/commit/eaccadec28fcde55236d9202637a8929feb8ce7a

Dill has to be dumped on the creation of the mirror agent function and not later.
Otherwise this leads to very unexpected behavior (storing the state of the variables at the time of dumping, which is then the same for all delayed agent_creators, leading to duplicate agent ids)

Furthermore, it was missing to call `on_ready` in mirror containers, which is fixed as well through this PR