### PR TITLE
allow to register agents after activation of container

### DIFF
--- a/mango/container/external_coupling.py
+++ b/mango/container/external_coupling.py
@@ -76,7 +76,6 @@ class ExternalSchedulingContainer(Container):
             **kwargs,
         )
 
-        self.running = True
         self.current_start_time_of_step = time.time()
         self._new_internal_message: bool = False
         self.message_buffer = []

--- a/mango/container/tcp.py
+++ b/mango/container/tcp.py
@@ -182,7 +182,6 @@ class TCPContainer(Container):
 
         self._tcp_connection_pool = None
         self.server = None  # will be set within start
-        self.running = False
         self._tcp_connection_pool = TCPConnectionPool(
             ttl_in_sec=self._kwargs.get(TCP_CONNECTION_TTL, 30),
             max_connections_per_target=self._kwargs.get(

--- a/tests/unit_tests/core/test_agent.py
+++ b/tests/unit_tests/core/test_agent.py
@@ -103,13 +103,21 @@ async def test_schedule_acl_message():
     assert agent2.test_counter == 1
 
 
-def test_register_twice():
+@pytest.mark.asyncio
+async def test_delayed_agent_creation():
+    # GIVEN
     c = create_tcp_container(addr=("127.0.0.1", 5555))
-    agent = MyAgent()
-    c.register(agent)
+    agent = c.register(MyAgent())
 
-    with pytest.raises(ValueError):
-        c.register(agent)
+    async with activate(c) as c:
+        agent2 = c.register(MyAgent())
+        await agent.schedule_instant_message(
+            create_acl("", receiver_addr=agent2.addr, sender_addr=agent.addr),
+            receiver_addr=agent2.addr,
+        )
+
+    # THEN
+    assert agent2.test_counter == 1
 
 
 def test_sync_setup_agent():

--- a/tests/unit_tests/core/test_agent_state.py
+++ b/tests/unit_tests/core/test_agent_state.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import pytest
+
+from mango import activate, create_ec_container
+from mango.agent.core import Agent
+
+
+class MyAgent(Agent):
+    test_counter: int = 0
+    ready = False
+    started = False
+    registered = False
+
+    def handle_message(self, content, meta: dict[str, Any]):
+        self.test_counter += 1
+
+    def on_ready(self):
+        self.ready = True
+
+    def on_start(self):
+        self.started = True
+
+    def on_register(self):
+        self.registered = True
+
+
+def test_register_twice():
+    c = create_ec_container()
+    agent = MyAgent()
+    c.register(agent)
+
+    with pytest.raises(ValueError):
+        c.register(agent)
+
+
+@pytest.mark.asyncio
+async def test_ready_twice():
+    c = create_ec_container()
+    agent = MyAgent()
+    c.register(agent)
+
+    await c.start()
+    c.on_ready()
+
+    with pytest.raises(RuntimeError):
+        c.on_ready()
+
+    await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_start_twice():
+    c = create_ec_container()
+    agent = MyAgent()
+    c.register(agent)
+
+    await c.start()
+    with pytest.raises(RuntimeError):
+        await c.start()
+
+    await c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_agent_state():
+    # GIVEN
+    c = create_ec_container()
+    agent = MyAgent()
+    assert agent.registered is False
+    assert agent.started is False
+    assert agent.ready is False
+
+    # WHEN
+    c.register(agent)
+
+    # THEN
+    assert agent.registered is True
+    assert agent.started is False
+    assert agent.ready is False
+
+    async with activate(c) as c:
+        assert agent.started is True
+        assert agent.ready is True
+
+
+@pytest.mark.asyncio
+async def test_delayed_agent_state():
+    # GIVEN
+    c = create_ec_container()
+
+    async with activate(c) as c:
+        agent = MyAgent()
+        assert agent.registered is False
+        c.register(agent)
+        assert agent.registered is True
+        assert agent.started is True
+        assert agent.ready is True


### PR DESCRIPTION
this makes sure that the `agent._do_start` and `agent.on_ready` functions are called as expected

this also fixes a bug in runtime management of the external_coupling container, which did set running before starting the container.