### PR TITLE
Fixing parsing of host:port string.

### DIFF
--- a/mango/container/factory.py
+++ b/mango/container/factory.py
@@ -78,7 +78,8 @@ def create_tcp(
     if clock is None:
         clock = AsyncioClock()
     if isinstance(addr, str):
-        addr = tuple(addr.split(":"))
+        host, port = addr.split(":")
+        addr = (host, int(port))
 
     # initialize TCPContainer
     return TCPContainer(

--- a/tests/unit_tests/core/test_container.py
+++ b/tests/unit_tests/core/test_container.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import pytest
 
 from mango import activate, create_acl, create_tcp_container
@@ -220,12 +222,34 @@ async def test_send_message_no_copy():
 async def test_send_message_copy():
     c = create_tcp_container(addr=("127.0.0.1", 5555), copy_internal_messages=True)
     agent1 = c.register(ExampleAgent())
+    agent2 = c.register(ExampleAgent())
+
     message_to_send = Data()
 
     async with activate(c):
-        await c.send_message(message_to_send, receiver_addr=agent1.addr)
+        await agent1.send_message(message_to_send, agent2.addr)
 
-    assert agent1.content is not message_to_send
+    assert agent2.content is not message_to_send
+
+
+@dataclass
+class DataCompl:
+    i = 0
+
+
+@pytest.mark.asyncio
+async def test_send_message_internal_cls():
+    c = create_tcp_container(addr="localhost:5555")
+    agent1 = c.register(ExampleAgent())
+    agent2 = c.register(ExampleAgent())
+
+    message_to_send = DataCompl()
+    addr = agent2.addr
+
+    async with activate(c):
+        await c.send_message(message_to_send, addr)
+
+    assert agent2.content is message_to_send
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This was problematic if you would use "host:port" notation, save a addr before activating, and then try to send messages with this saved addr. This makes the internal messaging check fail and it will be sent as external message, which is obviously not the point of internal messaging. 