### PR TITLE
Add option to set multiprocessing method through mp_method param in container

### DIFF
--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -32,6 +32,7 @@ class Container(ABC):
         clock: Clock,
         copy_internal_messages=False,
         mirror_data=None,
+        mp_method="spawn",
         **kwargs,
     ):
         self.name: str = name
@@ -64,7 +65,9 @@ class Container(ABC):
                 self, self._mirror_data
             )
         else:
-            self._container_process_manager = MainContainerProcessManager(self)
+            self._container_process_manager = MainContainerProcessManager(
+                self, mp_method
+            )
 
     def _all_aids(self):
         all_aids = list(self._agents.keys()) + self._container_process_manager.aids


### PR DESCRIPTION
Closes #139

The deadlock warning looks like it is not needed:
https://github.com/python/cpython/issues/114041#issuecomment-1925556936

Looks like we as well have a pool from which the processes are forked. As long as this is the only part where forking happens, I think we are save..?

The mp_method can be set in the create_tcp_container methods and so on as well