### PR TITLE
improve mqtt QoS and return types

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,6 +35,11 @@ We recommend Mosquitto__. On Debian/Ubuntu it can be installed as follows:
 
     $ sudo apt-get install mosquitto
 
+
+Note that mosquitto requires to have a config since v2.x for it to be accessible from outside your machine.
+It may as well be desired to set the option `set_tcp_nodelay=true` in the `mosquitto.conf` to improve round-trip time.
+Using the default QoS setting of 0 is recommended.
+
 __ https://mosquitto.org/
 
 

--- a/mango/agent/core.py
+++ b/mango/agent/core.py
@@ -65,7 +65,7 @@ class AgentContext:
         receiver_addr: AgentAddress,
         sender_id: None | str = None,
         **kwargs,
-    ):
+    ) -> bool:
         """
         See container.send_message(...)
         """
@@ -114,7 +114,7 @@ class AgentDelegates:
         content,
         receiver_addr: AgentAddress,
         **kwargs,
-    ):
+    ) -> bool:
         """
         See container.send_message(...)
         """

--- a/mango/agent/role.py
+++ b/mango/agent/role.py
@@ -336,7 +336,7 @@ class RoleContext(AgentDelegates):
         content,
         receiver_addr: AgentAddress,
         **kwargs,
-    ):
+    ) -> bool:
         self._role_handler._notify_send_message_subs(content, receiver_addr, **kwargs)
         return await self.context.send_message(
             content=content,

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -181,11 +181,10 @@ class Container(ABC):
 
         # first delegate to process manager to possibly reroute the message
         if receiver_id not in self._agents:
-            (
-                result,
-                inbox_overwrite,
-            ) = self._container_process_manager.pre_hook_send_internal_message(
-                message, receiver_id, priority, default_meta
+            result, inbox_overwrite = (
+                self._container_process_manager.pre_hook_send_internal_message(
+                    message, receiver_id, priority, default_meta
+                )
             )
             if result is not None:
                 return result

--- a/mango/container/external_coupling.py
+++ b/mango/container/external_coupling.py
@@ -111,12 +111,11 @@ class ExternalSchedulingContainer(Container):
                 message=message, receiver_id=receiver_id, default_meta=meta
             )
             self._new_internal_message = True
+            return success
         else:
             if not hasattr(content, "split_content_and_meta"):
                 message = MangoMessage(content, meta)
-            success = await self._send_external_message(receiver_addr, message)
-
-        return success
+            return await self._send_external_message(receiver_addr, message)
 
     async def _send_external_message(self, addr, message) -> bool:
         """

--- a/mango/container/mp.py
+++ b/mango/container/mp.py
@@ -205,7 +205,7 @@ class BaseContainerProcessManager:
 
     def pre_hook_send_internal_message(
         self, message, receiver_id, priority, default_meta
-    ):
+    ) -> tuple[bool, str]:
         """Hook in before an internal message is sent. Capable of preventing the default
         send_internal_message call.
         Therefore this method is able to reroute messages without side effects.
@@ -340,7 +340,7 @@ class MirrorContainerProcessManager(BaseContainerProcessManager):
 
     def pre_hook_send_internal_message(
         self, message, receiver_id, priority, default_meta
-    ):
+    ) -> tuple[bool, str]:
         self._out_queue.put_nowait((message, receiver_id, priority, default_meta))
         return True, None
 
@@ -436,7 +436,7 @@ class MainContainerProcessManager(BaseContainerProcessManager):
 
     def pre_hook_send_internal_message(
         self, message, receiver_id, priority, default_meta
-    ):
+    ) -> tuple[bool, str]:
         target_inbox = None
         if self._active:
             target_inbox = self._find_sp_queue(receiver_id)

--- a/mango/container/tcp.py
+++ b/mango/container/tcp.py
@@ -239,7 +239,7 @@ class TCPContainer(Container):
         if protocol_addr == self.addr:
             # internal message
             meta["network_protocol"] = "tcp"
-            success = self._send_internal_message(
+            return self._send_internal_message(
                 content, receiver_addr.aid, default_meta=meta
             )
         else:
@@ -247,11 +247,9 @@ class TCPContainer(Container):
             # if the user does not provide a splittable content, we create the default one
             if not hasattr(content, "split_content_and_meta"):
                 message = MangoMessage(content, meta)
-            success = await self._send_external_message(
+            return await self._send_external_message(
                 receiver_addr.protocol_addr, message, meta
             )
-
-        return success
 
     async def _send_external_message(self, addr, message, meta) -> bool:
         """


### PR DESCRIPTION
The return parameter of send_message was used inconsistently.
This is fixed through this PR.

fixes #31

I benchmarked the code a little with the code given in #142 for different QoS and transport methods.
Using the default TCP with default QoS of 0 seems to be the desirable choice.

Note that the QoS of the subscribe side, is used as a maximum QoS supported.

It is desired to use `set_tcp_nodelay=true` for MQTT brokers to reduce the roundtrip time as noted in #142 