### PR TITLE
improve error handling, through additional exception handler in done_callback

### DIFF
--- a/mango/util/distributed_clock.py
+++ b/mango/util/distributed_clock.py
@@ -121,11 +121,11 @@ class DistributedClockManager(ClockAgent):
         if self.schedules:
             next_event = min(self.schedules)
         else:
-            logger.warning("%s: no new events, time stands still", self.aid)
+            logger.info("%s: no new events, time stands still", self.aid)
             next_event = self.scheduler.clock.time
 
         if next_event < self.scheduler.clock.time:
-            logger.warning("%s: got old event, time stands still", self.aid)
+            logger.info("%s: got old event, time stands still", self.aid)
             next_event = self.scheduler.clock.time
         logger.debug("next event at %s", next_event)
         return next_event


### PR DESCRIPTION
These exception fail silently otherwise.

We can think about letting users handle this on their own by having a construct like, though I like to provide users with a decent error messages by default:

```python
def handle_exception(loop, context):
    # context["message"] will always be there; but context["exception"] may not
    msg = context.get("exception", context["message"])
    logger.exception(f"Caught exception: {msg}")

...

self.loop.set_exception_handler(handle_exception)
```
and adding this to the task loop through `set_exception_handler`


We also reduce the log messages in the distributed_clock as this is more of an info