### PR TITLE
scheduling: fix scheduling times in UTC timezone instead of local time

### DIFF
--- a/mango/util/scheduling.py
+++ b/mango/util/scheduling.py
@@ -4,11 +4,11 @@ Module for commonly used time based scheduled task executed inside one agent.
 
 import asyncio
 import concurrent.futures
-import datetime
 import logging
 from abc import abstractmethod
 from asyncio import Future
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from multiprocessing import Manager
 from multiprocessing.synchronize import Event as MultiprocessingEvent
 from typing import Any
@@ -299,7 +299,9 @@ class RecurrentScheduledTask(ScheduledTask):
 
     async def run(self):
         while not self._stopped:
-            current_time = datetime.datetime.fromtimestamp(self.clock.time)
+            current_time = datetime.fromtimestamp(
+                self.clock.time, tz=timezone.utc
+            ).replace(tzinfo=None)
             after = self._recurrency_rule.after(current_time)
             # after can be None, if until or count was set on the rrule
             if after is None:


### PR DESCRIPTION
When using the RecurrentScheduledTime, I would expect to have the time interpreted in UTC.

Conversion between timestamp and datetime is generally depending on the host timezone.

For example:

```python
>>> datetime.fromtimestamp(0, tz=timezone.utc).replace(tzinfo=None)
datetime.datetime(1970, 1, 1, 0, 0)
>>> datetime.fromtimestamp(0)
datetime.datetime(1970, 1, 1, 1, 0)

>>> datetime(1970,1,1).timestamp()
-3600.0
>>> import calendar
>>> calendar.timegm(datetime(1970,1,1).utctimetuple())
0
```

For a simulation tool, this is rather not expected as this gives different results depending on the host location, so I would rather expect it to use UTC wherever possible.
This is done in this PR, though remaining occurances in test functions of `datetime.timestamp()` are still present.