### PR TITLE
get_role helper to get access to a different role of the same agent

### DIFF
--- a/mango/agent/role.py
+++ b/mango/agent/role.py
@@ -308,6 +308,16 @@ class RoleContext(AgentDelegates):
         # Setup role
         role.setup()
 
+    def get_role(self, cls: type) -> Role | None:
+        """
+        returns the first role of a given class
+        returns None if no role of this type exists in the current context
+        """
+        for role in self._role_handler.roles:
+            if isinstance(role, cls):
+                return role
+        return None
+
     def remove_role(self, role: Role):
         """Remove a role and call on_stop for clean up
 

--- a/tests/unit_tests/role/role_test.py
+++ b/tests/unit_tests/role/role_test.py
@@ -157,3 +157,28 @@ def test_data_container_get():
     assert data_container.cba == 123
     assert data_container.get("abc") == "123"
     assert data_container.get("bca") is None
+
+
+def test_get_role():
+    role_handler = RoleHandler(None)
+    context = RoleContext(role_handler, None, None)
+    # returns None as no role was added yet
+    assert context.get_role(SubRole) is None
+    ex_role = SubRole()
+    ex_role2 = RoleHandlingEvents()
+    ex_role3 = SubRole()
+    context.add_role(ex_role)
+
+    res_role = context.get_role(SubRole)
+    assert res_role == ex_role
+
+    context.add_role(ex_role2)
+    res_role = context.get_role(RoleHandlingEvents)
+    # res_role is the role object of the RoleHandlingEvents
+    assert res_role == ex_role2
+
+    ex_role3 = SubRole()
+    context.add_role(ex_role3)
+    res_role = context.get_role(SubRole)
+    # res_role is the role added first
+    assert res_role == ex_role


### PR DESCRIPTION
I'd like to have a feature like this to directly call a method of a given role from a role which extends the behavior of a different role.

We could instead change this to return the result of the function call directly, which would make adding params a little weirder though.

No tests yet, will be added once the idea is discussed :)

What do you think? @rcschrg 