### PR TITLE
mqtt: only disconnect mqtt_client if initialized

### DIFF
--- a/mango/container/mqtt.py
+++ b/mango/container/mqtt.py
@@ -480,5 +480,6 @@ class MQTTContainer(Container):
         """
         await super().shutdown()
         # disconnect to broker
-        self.mqtt_client.disconnect()
-        self.mqtt_client.loop_stop()
+        if self.mqtt_client is not None:
+            self.mqtt_client.disconnect()
+            self.mqtt_client.loop_stop()


### PR DESCRIPTION
the mqtt_mirror_container_creator does not have a mqtt_client itself, which throws an error during shutdown.

this also happens if the container is shut down before running start method. Fix this by checking if the mqtt_client is set