### PR TITLE
mqtt: resubscribe inbox topic on reconnect

### DIFF
--- a/mango/container/mqtt.py
+++ b/mango/container/mqtt.py
@@ -290,7 +290,12 @@ class MQTTContainer(Container):
             # update meta dict
             meta.update(message_meta)
             # put information to inbox
-            self._loop.call_soon_threadsafe(self.inbox.put_nowait, (0, content, meta))
+            if self.inbox is None:
+                logger.warning("Inbox is not set yet")
+            else:
+                self._loop.call_soon_threadsafe(
+                    self.inbox.put_nowait, (0, content, meta)
+                )
 
         self.mqtt_client.on_message = on_message
         self.mqtt_client.enable_logger(logger)


### PR DESCRIPTION
unify call to `_send_external_message` by making it async as the other containers

catch `RuntimeError` when `send_external_message` fails - this does not resubmit the message to the broker yet

related to #97 

This does not yet fix all issues when the broker goes down, as messages are lost and not sent again.
Would be good to handle this in the agent framework and not in the simulation itself.