### PR TITLE
Add live topology UI dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ docs/source/_build
 
 # Git
 *.orig
+
+# Claude stuff
+.claude/
+

--- a/mango/agent/core.py
+++ b/mango/agent/core.py
@@ -384,15 +384,17 @@ class AgentDelegates:
 class Agent(ABC, AgentDelegates):
     """Base class for all agents."""
 
-    def __init__(
-        self,
-    ):
+    def __init__(self, visible: bool = True):
         """
         Initialize an agent
+
+        :param visible: whether this agent is reported to a TopologyRegistry,
+            defaults to True
         """
 
         super().__init__()
 
+        self._visible = visible
         self.inbox = asyncio.Queue()
         self.context = AgentContext(None)
 

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -59,6 +59,8 @@ class Container(ABC):
         self._kwargs = kwargs
         self._mirror_data = mirror_data
 
+        self._registry = None  # set by TopologyRegistry.register(container)
+
         # multiprocessing
         if self._mirror_data is not None:
             self._container_process_manager = MirrorContainerProcessManager(
@@ -133,6 +135,10 @@ class Container(ABC):
 
         if self.ready:
             agent.on_ready()
+
+        if self._registry is not None and getattr(agent, "_visible", True):
+            self._registry.on_agent_registered(self, agent, aid)
+
         return agent
 
     def _get_aid(self, agent):
@@ -148,6 +154,8 @@ class Container(ABC):
         :param aid:
         :return:
         """
+        if self._registry is not None:
+            self._registry.on_agent_deregistered(self, aid)
         del self._agents[aid]
 
     @abstractmethod

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -71,6 +71,11 @@ class Container(ABC):
                 self, mp_method
             )
 
+    @property
+    def registry(self):
+        """The TopologyRegistry this container reports to, if any (see `activate(ui=True)`)."""
+        return self._registry
+
     def _all_aids(self):
         all_aids = list(self._agents.keys()) + self._container_process_manager.aids
 

--- a/mango/container/core.py
+++ b/mango/container/core.py
@@ -363,7 +363,15 @@ class Container(ABC):
             futs.append(agent.shutdown())
         await asyncio.gather(*futs)
 
+        if self._registry is not None:
+            for aid in list(self._agents.keys()):
+                self._registry.on_agent_deregistered(self, aid)
+
+        # this also deregisters agents living in subprocesses, if any
         await self._container_process_manager.shutdown()
+
+        if self._registry is not None:
+            self._registry.on_container_removed(self)
 
         # cancel check inbox task
         if self._check_inbox_task is not None:

--- a/mango/container/mp.py
+++ b/mango/container/mp.py
@@ -591,6 +591,13 @@ class MainContainerProcessManager(BaseContainerProcessManager):
 
     async def shutdown(self):
         if self._active:
+            if self._container._registry is not None:
+                for aids in self._pid_to_aids.values():
+                    for aid in aids:
+                        self._container._registry.on_agent_deregistered(
+                            self._container, aid
+                        )
+
             # send a signal to all sub processes to terminate their message feed in's
             self._terminate_sub_processes.set()
 

--- a/mango/express/api.py
+++ b/mango/express/api.py
@@ -13,13 +13,29 @@ logger = logging.getLogger(__name__)
 
 
 class ContainerActivationManager:
-    def __init__(self, containers: list[Container]) -> None:
+    def __init__(
+        self,
+        containers: list[Container],
+        ui: bool = False,
+        ui_host: str = "localhost",
+        ui_port: int = 8000,
+    ) -> None:
         self._containers = containers
+        self._ui = ui
+        self._ui_host = ui_host
+        self._ui_port = ui_port
 
     async def __aenter__(self):
         await asyncio.gather(*[c.start() for c in self._containers])
         for container in self._containers:
             container.on_ready()
+        if self._ui:
+            from ..ui import TopologyRegistry
+
+            registry = TopologyRegistry()
+            for container in self._containers:
+                registry.register(container)
+            await registry.start_server(host=self._ui_host, port=self._ui_port)
         if len(self._containers) == 1:
             return self._containers[0]
         return self._containers
@@ -132,7 +148,12 @@ class RunWithMQTTManager(RunWithContainer):
                 await container.subscribe_for_agent(aid=actual_agent.aid, topic=topic)
 
 
-def activate(*containers: Container) -> ContainerActivationManager:
+def activate(
+    *containers: Container,
+    ui: bool = False,
+    ui_host: str = "localhost",
+    ui_port: int = 8000,
+) -> ContainerActivationManager:
     """
     Create and return an async activation context manager.
     This can be used with the `async with` syntax to run code while the container(s) are active.
@@ -151,12 +172,23 @@ def activate(*containers: Container) -> ContainerActivationManager:
         async with activate(container_list) as container_list:
             # do your stuff
 
+        # With the topology UI enabled (requires the `ui` extra)
+        async with activate(container_a, container_b, ui=True) as (container_a, container_b):
+            container_a.registry.add_connection(agent_one.addr, agent_two.addr)
+
+    :param ui: if True, start the topology UI web server once the containers
+        are running, and register all of them with it. Access the registry
+        afterwards via `container.registry` (e.g. to call `add_connection`).
+    :param ui_host: host the UI server binds to, defaults to "localhost"
+    :param ui_port: port the UI server binds to, defaults to 8000
     :return: The context manager to be used as described
     :rtype: ContainerActivationManager
     """
     if isinstance(containers[0], list):
         containers = containers[0]
-    return ContainerActivationManager(list(containers))
+    return ContainerActivationManager(
+        list(containers), ui=ui, ui_host=ui_host, ui_port=ui_port
+    )
 
 
 def run_with_tcp(

--- a/mango/express/api.py
+++ b/mango/express/api.py
@@ -24,6 +24,7 @@ class ContainerActivationManager:
         self._ui = ui
         self._ui_host = ui_host
         self._ui_port = ui_port
+        self._registry = None
 
     async def __aenter__(self):
         await asyncio.gather(*[c.start() for c in self._containers])
@@ -32,16 +33,18 @@ class ContainerActivationManager:
         if self._ui:
             from ..ui import TopologyRegistry
 
-            registry = TopologyRegistry()
+            self._registry = TopologyRegistry()
             for container in self._containers:
-                registry.register(container)
-            await registry.start_server(host=self._ui_host, port=self._ui_port)
+                self._registry.register(container)
+            await self._registry.start_server(host=self._ui_host, port=self._ui_port)
         if len(self._containers) == 1:
             return self._containers[0]
         return self._containers
 
     async def __aexit__(self, exc_type, exc, tb):
         await asyncio.gather(*[c.shutdown() for c in self._containers])
+        if self._registry is not None:
+            await self._registry.stop_server()
 
 
 class RunWithContainer(ABC):

--- a/mango/ui/__init__.py
+++ b/mango/ui/__init__.py
@@ -1,0 +1,3 @@
+from .registry import TopologyRegistry, ConnectionInfo
+
+__all__ = ["TopologyRegistry", "ConnectionInfo"]

--- a/mango/ui/registry.py
+++ b/mango/ui/registry.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,8 @@ class TopologyRegistry:
         self._agents: dict[str, AgentInfo] = {}
         self._connections: list[ConnectionInfo] = []
         self._ws_clients: set = set()
+        self._uvicorn_server = None
+        self._server_task = None
 
     def register(self, container) -> None:
         """Register a container with this registry."""
@@ -57,6 +59,15 @@ class TopologyRegistry:
                 self._agents[f"{addr_str}:{aid}"] = AgentInfo(
                     aid=aid, container_addr=addr_str
                 )
+        # agents living in subprocesses (see Container.as_agent_process) have
+        # no Agent object in this process to check `_visible` on, so they are
+        # always treated as visible. This is a one-time backfill, so subprocess
+        # agents created after this call (i.e. inside an active `activate(ui=True)`
+        # block) won't be picked up either.
+        for aid in container._container_process_manager.aids:
+            self._agents[f"{addr_str}:{aid}"] = AgentInfo(
+                aid=aid, container_addr=addr_str
+            )
 
     def add_connection(
         self,
@@ -118,6 +129,12 @@ class TopologyRegistry:
         self._agents.pop(f"{addr_str}:{aid}", None)
         self._broadcast()
 
+    def on_container_removed(self, container) -> None:
+        addr_str = str(container.addr)
+        self._containers.pop(addr_str, None)
+        self._container_refs.pop(addr_str, None)
+        self._broadcast()
+
     # ------------------------------------------------------------------
     # WebSocket / server
     # ------------------------------------------------------------------
@@ -139,9 +156,18 @@ class TopologyRegistry:
 
         app = create_app(self)
         config = uvicorn.Config(app, host=host, port=port, log_level="warning")
-        server = uvicorn.Server(config)
-        asyncio.ensure_future(server.serve())
+        self._uvicorn_server = uvicorn.Server(config)
+        self._server_task = asyncio.ensure_future(self._uvicorn_server.serve())
         logger.info("Topology UI available at http://%s:%d", host, port)
+
+    async def stop_server(self) -> None:
+        """Stop the UI server started via `start_server`, if any."""
+        if self._uvicorn_server is None:
+            return
+        self._uvicorn_server.should_exit = True
+        await self._server_task
+        self._uvicorn_server = None
+        self._server_task = None
 
     async def _connect_client(self, ws) -> None:
         self._ws_clients.add(ws)

--- a/mango/ui/registry.py
+++ b/mango/ui/registry.py
@@ -1,0 +1,169 @@
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, asdict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConnectionInfo:
+    source_addr: str
+    source_aid: str
+    target_addr: str
+    target_aid: str
+    conn_type: str = "tcp"  # tcp | mqtt | internal
+    direction: str = "bi"   # uni | bi
+
+
+@dataclass
+class AgentInfo:
+    aid: str
+    container_addr: str
+    status: str = "active"
+
+
+@dataclass
+class ContainerInfo:
+    addr: str
+    name: str
+
+
+class TopologyRegistry:
+    """Registry that sits above containers and tracks agents, connections,
+    and infrastructure health. Containers opt in by calling registry.register(container).
+    Agents opt in via visible=True (default) in their __init__.
+    """
+
+    def __init__(self):
+        self._container_refs: dict[str, object] = {}
+        self._containers: dict[str, ContainerInfo] = {}
+        self._agents: dict[str, AgentInfo] = {}
+        self._connections: list[ConnectionInfo] = []
+        self._ws_clients: set = set()
+
+    def register(self, container) -> None:
+        """Register a container with this registry."""
+        container._registry = self
+        addr_str = str(container.addr)
+        self._container_refs[addr_str] = container
+        self._containers[addr_str] = ContainerInfo(
+            addr=addr_str,
+            name=getattr(container, "name", addr_str) or addr_str,
+        )
+        # pick up agents already registered before this call
+        for aid, agent in container._agents.items():
+            if getattr(agent, "_visible", True):
+                self._agents[f"{addr_str}:{aid}"] = AgentInfo(
+                    aid=aid, container_addr=addr_str
+                )
+
+    def add_connection(
+        self,
+        source,
+        target,
+        conn_type: str = "tcp",
+        direction: str = "bi",
+    ) -> None:
+        """Declare a connection between two agents.
+
+        source / target are AgentAddress objects (protocol_addr, aid).
+        """
+        self._connections.append(
+            ConnectionInfo(
+                source_addr=str(source.protocol_addr),
+                source_aid=source.aid,
+                target_addr=str(target.protocol_addr),
+                target_aid=target.aid,
+                conn_type=conn_type,
+                direction=direction,
+            )
+        )
+        self._broadcast()
+
+    async def check_health(self) -> None:
+        """Poll each visible agent for its health status.
+
+        Agents can optionally implement ``async def health_check(self) -> str``
+        returning a status string (e.g. "active", "idle", "error").
+        """
+        for key, info in list(self._agents.items()):
+            container = self._container_refs.get(info.container_addr)
+            if container is None:
+                continue
+            agent = container._agents.get(info.aid)
+            if agent is None:
+                continue
+            if hasattr(agent, "health_check"):
+                try:
+                    status = await agent.health_check()
+                    info.status = str(status)
+                except Exception:
+                    info.status = "error"
+        self._broadcast()
+
+    # ------------------------------------------------------------------
+    # Called by Container hooks
+    # ------------------------------------------------------------------
+
+    def on_agent_registered(self, container, agent, aid: str) -> None:
+        addr_str = str(container.addr)
+        self._agents[f"{addr_str}:{aid}"] = AgentInfo(
+            aid=aid, container_addr=addr_str
+        )
+        self._broadcast()
+
+    def on_agent_deregistered(self, container, aid: str) -> None:
+        addr_str = str(container.addr)
+        self._agents.pop(f"{addr_str}:{aid}", None)
+        self._broadcast()
+
+    # ------------------------------------------------------------------
+    # WebSocket / server
+    # ------------------------------------------------------------------
+
+    async def start_server(self, host: str = "localhost", port: int = 8000) -> None:
+        """Start the UI server inside the running asyncio loop.
+
+        Call this after activate() so the loop is already running.
+        """
+        try:
+            import uvicorn
+        except ImportError as exc:
+            raise ImportError(
+                "Install mango-agents[ui] to use the topology UI: "
+                "pip install mango-agents[ui]"
+            ) from exc
+
+        from .server import create_app
+
+        app = create_app(self)
+        config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+        server = uvicorn.Server(config)
+        asyncio.ensure_future(server.serve())
+        logger.info("Topology UI available at http://%s:%d", host, port)
+
+    async def _connect_client(self, ws) -> None:
+        self._ws_clients.add(ws)
+        await ws.send_text(json.dumps(self._snapshot()))
+
+    def _disconnect_client(self, ws) -> None:
+        self._ws_clients.discard(ws)
+
+    def _broadcast(self) -> None:
+        if not self._ws_clients:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # loop not running yet; clients get full state on connect
+        data = json.dumps(self._snapshot())
+        for ws in list(self._ws_clients):
+            loop.create_task(ws.send_text(data))
+
+    def _snapshot(self) -> dict:
+        return {
+            "containers": [asdict(c) for c in self._containers.values()],
+            "agents": [asdict(a) for a in self._agents.values()],
+            "connections": [asdict(c) for c in self._connections],
+        }

--- a/mango/ui/server.py
+++ b/mango/ui/server.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+
+_STATIC = Path(__file__).parent / "static"
+
+
+def create_app(registry):
+    app = FastAPI(title="mango topology")
+
+    @app.get("/")
+    async def index():
+        return HTMLResponse((_STATIC / "index.html").read_text())
+
+    @app.websocket("/ws")
+    async def ws_endpoint(websocket: WebSocket):
+        await websocket.accept()
+        await registry._connect_client(websocket)
+        try:
+            while True:
+                await websocket.receive_text()  # keep-alive; client sends nothing
+        except WebSocketDisconnect:
+            registry._disconnect_client(websocket)
+
+    return app

--- a/mango/ui/static/index.html
+++ b/mango/ui/static/index.html
@@ -3,8 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <title>mango — topology</title>
-  <script src="https://unpkg.com/graphology@0.25.4/dist/graphology.umd.min.js"></script>
-  <script src="https://unpkg.com/sigma@2.4.0/build/sigma.min.js"></script>
+  <script src="https://unpkg.com/cytoscape@3.30.0/dist/cytoscape.min.js"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -226,33 +225,33 @@
 
   // ── State ────────────────────────────────────────────────────────────────────
 
-  let sigma  = null;
-  let graph  = null;
+  let cy = null;
 
   // ── Layout ───────────────────────────────────────────────────────────────────
 
   function layout(data) {
-    const pos     = {};
-    const cCount  = data.containers.length;
-    const SPREAD  = 5;   // horizontal gap between containers
-    const RADIUS  = 2.2; // agent orbit radius
+    const pos    = {};
+    const cCount = data.containers.length;
+    const SPREAD = 5;
+    const RADIUS = 2.2;
+    const SCALE  = 80;  // graph units → cytoscape pixel coords
 
     data.containers.forEach((c, ci) => {
       const cx = (ci - (cCount - 1) / 2) * SPREAD;
-      pos['c:' + c.addr] = { x: cx, y: 0 };
+      pos['c:' + c.addr] = { x: cx * SCALE, y: 0 };
 
       const mine = data.agents.filter(a => a.container_addr === c.addr);
       const n    = mine.length;
 
       mine.forEach((a, ai) => {
-        // fan below the container (-120° to -60°, centered at -90°)
         const angle = n === 1
           ? -Math.PI / 2
           : -Math.PI / 2 + ((ai / (n - 1)) - 0.5) * Math.PI * 1.1;
 
+        // cytoscape y increases downward, so negate the math-y to place agents below containers
         pos['a:' + a.container_addr + ':' + a.aid] = {
-          x: cx + RADIUS * Math.cos(angle),
-          y: RADIUS * Math.sin(angle) - 1,
+          x:  (cx + RADIUS * Math.cos(angle)) * SCALE,
+          y: -(RADIUS * Math.sin(angle) - 1)  * SCALE,
         };
       });
     });
@@ -260,109 +259,134 @@
     return pos;
   }
 
-  // ── Build graphology graph ───────────────────────────────────────────────────
+  // ── Build cytoscape elements ─────────────────────────────────────────────────
 
-  function buildGraph(data) {
-    const g   = new graphology.MultiGraph();
-    const pos = layout(data);
+  function buildElements(data) {
+    const pos  = layout(data);
+    const eles = [];
 
-    // container nodes — larger, accent border
     data.containers.forEach(c => {
       const id = 'c:' + c.addr;
-      const p  = pos[id] || { x: 0, y: 0 };
-      g.addNode(id, {
-        label:       c.name,
-        x: p.x, y: p.y,
-        size:        20,
-        color:       '#1f2937',
-        borderColor: '#388bfd',
-        kind:        'container',
-        raw:         c,
-      });
+      eles.push({ data: { id, label: c.name, kind: 'container', raw: c },
+                  position: pos[id] || { x: 0, y: 0 } });
     });
 
-    // agent nodes + thin membership edges
     data.agents.forEach(a => {
       const id = 'a:' + a.container_addr + ':' + a.aid;
-      const p  = pos[id] || { x: 0, y: -2 };
       const sc = STATUS_COLORS[a.status] || '#8b949e';
+      eles.push({ data: { id, label: a.aid, kind: 'agent', color: sc, raw: a },
+                  position: pos[id] || { x: 0, y: 100 } });
 
-      g.addNode(id, {
-        label: a.aid,
-        x: p.x, y: p.y,
-        size:  13,
-        color: sc,
-        kind:  'agent',
-        raw:   a,
-      });
-
-      // membership edge
-      if (g.hasNode('c:' + a.container_addr)) {
-        g.addEdge('c:' + a.container_addr, id, {
-          color:  '#21262d',
-          size:   1,
-          type:   'line',
-          label:  '',
+      if (data.containers.find(c => c.addr === a.container_addr)) {
+        eles.push({ data: {
+          id:     'em:' + a.container_addr + ':' + a.aid,
+          source: 'c:' + a.container_addr,
+          target: id,
           kind:   'member',
-        });
+        }});
       }
     });
 
-    // declared connection edges
-    data.connections.forEach(c => {
+    data.connections.forEach((c, i) => {
       const color = CONN_COLORS[c.conn_type] || '#8b949e';
       const src   = 'a:' + c.source_addr + ':' + c.source_aid;
       const tgt   = 'a:' + c.target_addr + ':' + c.target_aid;
 
-      if (!g.hasNode(src) || !g.hasNode(tgt)) return;
-
-      g.addEdge(src, tgt, {
-        color, size: 2.5,
-        type:  'arrow',
-        label: c.conn_type,
-        kind:  'connection',
-      });
+      eles.push({ data: { id: 'ec:' + i, source: src, target: tgt,
+                          kind: 'connection', color, label: c.conn_type }});
 
       if (c.direction === 'bi') {
-        g.addEdge(tgt, src, {
-          color, size: 2.5,
-          type:  'arrow',
-          label: '',
-          kind:  'connection',
-        });
+        eles.push({ data: { id: 'ec:bi:' + i, source: tgt, target: src,
+                            kind: 'connection', color, label: '' }});
       }
     });
 
-    return g;
+    return eles;
   }
 
   // ── Renderer ─────────────────────────────────────────────────────────────────
 
-  function initSigma(g) {
-    if (sigma) { sigma.kill(); sigma = null; }
-
-    sigma = new Sigma(g, document.getElementById('sigma-canvas'), {
-      renderEdgeLabels:  true,
-      defaultEdgeType:   'arrow',
-      labelColor:        { color: '#c9d1d9' },
-      labelSize:         13,
-      labelWeight:       '600',
-      labelRenderedSizeThreshold: 6,
-      edgeLabelColor:    { color: '#8b949e' },
-      edgeLabelSize:     10,
-      defaultNodeColor:  '#21262d',
-      defaultEdgeColor:  '#30363d',
-      minCameraRatio:    0.05,
-      maxCameraRatio:    20,
+  function initCy(eles) {
+    cy = cytoscape({
+      container: document.getElementById('sigma-canvas'),
+      elements:  eles,
+      layout:    { name: 'preset' },
+      style: [
+        {
+          selector: 'node[kind = "container"]',
+          style: {
+            'width':            40,
+            'height':           40,
+            'background-color': '#1f2937',
+            'border-color':     '#388bfd',
+            'border-width':     2,
+            'label':            'data(label)',
+            'color':            '#c9d1d9',
+            'font-size':        13,
+            'font-family':      'SF Mono, Fira Code, Cascadia Code, monospace',
+            'font-weight':      600,
+            'text-valign':      'bottom',
+            'text-margin-y':    8,
+          },
+        },
+        {
+          selector: 'node[kind = "agent"]',
+          style: {
+            'width':            26,
+            'height':           26,
+            'background-color': 'data(color)',
+            'label':            'data(label)',
+            'color':            '#c9d1d9',
+            'font-size':        11,
+            'font-family':      'SF Mono, Fira Code, Cascadia Code, monospace',
+            'font-weight':      600,
+            'text-valign':      'bottom',
+            'text-margin-y':    6,
+          },
+        },
+        {
+          selector: 'edge',
+          style: {
+            'line-color':              'data(color)',
+            'width':                   2.5,
+            'target-arrow-color':      'data(color)',
+            'target-arrow-shape':      'triangle',
+            'curve-style':             'bezier',
+            'label':                   'data(label)',
+            'font-size':               10,
+            'color':                   '#8b949e',
+            'font-family':             'SF Mono, Fira Code, Cascadia Code, monospace',
+            'text-rotation':           'autorotate',
+            'text-background-color':   '#0a0e17',
+            'text-background-opacity': 0.8,
+            'text-background-padding': '2px',
+          },
+        },
+        {
+          selector: 'edge[kind = "member"]',
+          style: {
+            'target-arrow-shape': 'none',
+            'line-style':         'dashed',
+            'line-color':         '#21262d',
+            'width':              1,
+          },
+        },
+      ],
+      userZoomingEnabled:  true,
+      userPanningEnabled:  true,
+      boxSelectionEnabled: false,
+      autounselectify:     true,
+      minZoom:             0.1,
+      maxZoom:             10,
     });
 
     // ── Tooltip ──────────────────────────────────────────────────────────────
 
     const ttEl = document.getElementById('tooltip');
 
-    sigma.on('enterNode', ({ node }) => {
-      const d = g.getNodeAttributes(node);
-      const r = d.raw || {};
+    cy.on('mouseover', 'node', e => {
+      const d  = e.target.data();
+      const r  = d.raw || {};
       let html = '';
 
       if (d.kind === 'container') {
@@ -375,15 +399,17 @@
                 <div class="tt-row">status <span style="color:${sc}">${r.status || 'unknown'}</span></div>`;
       }
 
-      ttEl.innerHTML = html;
+      ttEl.innerHTML     = html;
       ttEl.style.display = 'block';
     });
 
-    sigma.on('leaveNode', () => { ttEl.style.display = 'none'; });
+    cy.on('mouseout', 'node', () => { ttEl.style.display = 'none'; });
 
-    sigma.getMouseCaptor().on('mousemove', e => {
-      ttEl.style.left = (e.x + 16) + 'px';
-      ttEl.style.top  = (e.y + 16) + 'px';
+    document.getElementById('sigma-canvas').addEventListener('mousemove', e => {
+      if (ttEl.style.display === 'block') {
+        ttEl.style.left = (e.clientX + 16) + 'px';
+        ttEl.style.top  = (e.clientY + 16) + 'px';
+      }
     });
 
     fitView();
@@ -392,61 +418,46 @@
   // ── Fit / zoom ────────────────────────────────────────────────────────────────
 
   function fitView() {
-    if (!sigma || !graph || !graph.order) return;
-
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    graph.forEachNode((_, { x, y }) => {
-      if (x < minX) minX = x; if (y < minY) minY = y;
-      if (x > maxX) maxX = x; if (y > maxY) maxY = y;
-    });
-
-    const cx     = (minX + maxX) / 2;
-    const cy     = (minY + maxY) / 2;
-    const rangeX = Math.max(maxX - minX, 1);
-    const rangeY = Math.max(maxY - minY, 1);
-
-    const wrap  = document.getElementById('sigma-wrap');
-    const wW    = wrap.clientWidth;
-    const wH    = wrap.clientHeight;
-
-    // sigma camera ratio: graph-units per pixel. Lower = more zoomed in.
-    const ratio = Math.max(rangeX / wW, rangeY / wH) * 1.5;
-
-    sigma.getCamera().animate(
-      { x: cx, y: cy, ratio, angle: 0 },
-      { duration: 400 }
-    );
+    if (!cy) return;
+    cy.animate({ fit: { eles: cy.elements(), padding: 60 } }, { duration: 400 });
   }
 
   // ── Controls ──────────────────────────────────────────────────────────────────
 
   document.getElementById('btn-fit').addEventListener('click', fitView);
   document.getElementById('btn-zoomin').addEventListener('click', () => {
-    sigma && sigma.getCamera().animatedZoom({ factor: 1.5, duration: 200 });
+    cy && cy.animate({ zoom: cy.zoom() * 1.5 }, { duration: 200 });
   });
   document.getElementById('btn-zoomout').addEventListener('click', () => {
-    sigma && sigma.getCamera().animatedUnzoom({ factor: 1.5, duration: 200 });
+    cy && cy.animate({ zoom: cy.zoom() / 1.5 }, { duration: 200 });
   });
 
   document.addEventListener('keydown', e => {
-    if (!sigma) return;
+    if (!cy) return;
     if (e.key === 'f' || e.key === 'F') fitView();
-    if (e.key === '+' || e.key === '=') sigma.getCamera().animatedZoom({ factor: 1.5, duration: 200 });
-    if (e.key === '-')                   sigma.getCamera().animatedUnzoom({ factor: 1.5, duration: 200 });
+    if (e.key === '+' || e.key === '=') cy.animate({ zoom: cy.zoom() * 1.5 }, { duration: 200 });
+    if (e.key === '-')                   cy.animate({ zoom: cy.zoom() / 1.5 }, { duration: 200 });
   });
 
   // ── Render ────────────────────────────────────────────────────────────────────
 
   function render(data) {
-    document.getElementById('n-containers').textContent = data.containers.length;
-    document.getElementById('n-agents').textContent     = data.agents.length;
+    document.getElementById('n-containers').textContent  = data.containers.length;
+    document.getElementById('n-agents').textContent      = data.agents.length;
     document.getElementById('n-connections').textContent = data.connections.length;
 
     const hasData = data.containers.length > 0 || data.agents.length > 0;
     document.getElementById('empty').classList.toggle('hidden', hasData);
 
-    graph = buildGraph(data);
-    initSigma(graph);
+    const eles = buildElements(data);
+
+    if (!cy) {
+      initCy(eles);
+    } else {
+      cy.elements().remove();
+      cy.add(eles);
+      fitView();
+    }
   }
 
   // ── WebSocket ─────────────────────────────────────────────────────────────────
@@ -458,11 +469,11 @@
     const ws = new WebSocket('ws://' + location.host + '/ws');
 
     ws.onopen = () => {
-      dot.className = 'live';
+      dot.className    = 'live';
       stxt.textContent = 'live';
     };
     ws.onclose = () => {
-      dot.className = 'dead';
+      dot.className    = 'dead';
       stxt.textContent = 'reconnecting…';
       setTimeout(connect, 2000);
     };

--- a/mango/ui/static/index.html
+++ b/mango/ui/static/index.html
@@ -1,0 +1,476 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>mango — topology</title>
+  <script src="https://unpkg.com/graphology@0.25.4/dist/graphology.umd.min.js"></script>
+  <script src="https://unpkg.com/sigma@2.4.0/build/sigma.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:        #0a0e17;
+      --surface:   #0d1117;
+      --surface2:  #161b22;
+      --border:    #21262d;
+      --text:      #c9d1d9;
+      --muted:     #8b949e;
+      --accent:    #58a6ff;
+      --green:     #3fb950;
+      --red:       #f85149;
+      --yellow:    #d29922;
+    }
+
+    body {
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* ── Header ───────────────────────────────────────── */
+    #header {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      padding: 0 20px;
+      height: 50px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    #logo {
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--accent);
+      letter-spacing: 4px;
+    }
+
+    .sep { width: 1px; height: 18px; background: var(--border); }
+
+    .pill {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 3px 10px;
+      border-radius: 20px;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      font-size: 11px;
+      color: var(--muted);
+    }
+
+    #dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: var(--border);
+      transition: background .3s, box-shadow .3s;
+    }
+    #dot.live  { background: var(--green); box-shadow: 0 0 7px var(--green); }
+    #dot.dead  { background: var(--red); }
+
+    #stats {
+      display: flex;
+      gap: 18px;
+      font-size: 11px;
+      color: var(--muted);
+    }
+    .stat b { color: var(--text); font-weight: 600; }
+
+    #legend {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      font-size: 11px;
+      color: var(--muted);
+    }
+    .leg { display: flex; align-items: center; gap: 6px; }
+    .leg-line { width: 20px; height: 2px; border-radius: 1px; }
+
+    /* ── Canvas ───────────────────────────────────────── */
+    #sigma-wrap {
+      flex: 1;
+      position: relative;
+      background: var(--bg);
+    }
+
+    #sigma-canvas {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* ── Controls ─────────────────────────────────────── */
+    #controls {
+      position: absolute;
+      bottom: 18px;
+      right: 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .ctrl-btn {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: inherit;
+      font-size: 13px;
+      width: 34px; height: 34px;
+      border-radius: 6px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background .15s;
+    }
+    .ctrl-btn:hover { background: var(--border); }
+
+    /* ── Tooltip ──────────────────────────────────────── */
+    #tooltip {
+      position: fixed;
+      display: none;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 14px;
+      font-size: 12px;
+      line-height: 1.7;
+      pointer-events: none;
+      z-index: 200;
+      min-width: 180px;
+      box-shadow: 0 6px 24px rgba(0,0,0,.5);
+    }
+    .tt-title { font-weight: 700; color: var(--text); margin-bottom: 4px; font-size: 13px; }
+    .tt-row   { color: var(--muted); }
+    .tt-row span { color: var(--text); }
+
+    /* ── Empty state ──────────────────────────────────── */
+    #empty {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      color: var(--muted);
+      font-size: 13px;
+      pointer-events: none;
+    }
+    #empty svg { opacity: .3; }
+    #empty.hidden { display: none; }
+  </style>
+</head>
+<body>
+
+<div id="header">
+  <div id="logo">mango</div>
+  <div class="sep"></div>
+  <div class="pill">
+    <div id="dot"></div>
+    <span id="status-text">connecting…</span>
+  </div>
+  <div id="stats">
+    <div class="stat"><b id="n-containers">0</b> containers</div>
+    <div class="stat"><b id="n-agents">0</b> agents</div>
+    <div class="stat"><b id="n-connections">0</b> connections</div>
+  </div>
+  <div id="legend">
+    <div class="leg"><div class="leg-line" style="background:#4a90d9"></div>tcp</div>
+    <div class="leg"><div class="leg-line" style="background:#f5a623"></div>mqtt</div>
+    <div class="leg"><div class="leg-line" style="background:#7ed321"></div>internal</div>
+    <div class="leg"><div class="leg-line" style="background:var(--border)"></div>member</div>
+  </div>
+</div>
+
+<div id="sigma-wrap">
+  <div id="sigma-canvas"></div>
+
+  <div id="empty">
+    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <circle cx="12" cy="12" r="10"/><circle cx="8" cy="10" r="1.5" fill="currentColor"/>
+      <circle cx="16" cy="10" r="1.5" fill="currentColor"/>
+      <path d="M8 14s1.5 2 4 2 4-2 4-2" stroke-linecap="round"/>
+    </svg>
+    <span>Waiting for topology data…</span>
+  </div>
+
+  <div id="controls">
+    <button class="ctrl-btn" id="btn-fit"   title="Fit view (F)">⊡</button>
+    <button class="ctrl-btn" id="btn-zoomin"  title="Zoom in (+)">+</button>
+    <button class="ctrl-btn" id="btn-zoomout" title="Zoom out (-)">−</button>
+  </div>
+</div>
+
+<div id="tooltip"></div>
+
+<script>
+  // ── Constants ────────────────────────────────────────────────────────────────
+
+  const CONN_COLORS = {
+    tcp:      '#4a90d9',
+    mqtt:     '#f5a623',
+    internal: '#7ed321',
+  };
+
+  const STATUS_COLORS = {
+    active: '#3fb950',
+    error:  '#f85149',
+    idle:   '#d29922',
+  };
+
+  // ── State ────────────────────────────────────────────────────────────────────
+
+  let sigma  = null;
+  let graph  = null;
+
+  // ── Layout ───────────────────────────────────────────────────────────────────
+
+  function layout(data) {
+    const pos     = {};
+    const cCount  = data.containers.length;
+    const SPREAD  = 5;   // horizontal gap between containers
+    const RADIUS  = 2.2; // agent orbit radius
+
+    data.containers.forEach((c, ci) => {
+      const cx = (ci - (cCount - 1) / 2) * SPREAD;
+      pos['c:' + c.addr] = { x: cx, y: 0 };
+
+      const mine = data.agents.filter(a => a.container_addr === c.addr);
+      const n    = mine.length;
+
+      mine.forEach((a, ai) => {
+        // fan below the container (-120° to -60°, centered at -90°)
+        const angle = n === 1
+          ? -Math.PI / 2
+          : -Math.PI / 2 + ((ai / (n - 1)) - 0.5) * Math.PI * 1.1;
+
+        pos['a:' + a.container_addr + ':' + a.aid] = {
+          x: cx + RADIUS * Math.cos(angle),
+          y: RADIUS * Math.sin(angle) - 1,
+        };
+      });
+    });
+
+    return pos;
+  }
+
+  // ── Build graphology graph ───────────────────────────────────────────────────
+
+  function buildGraph(data) {
+    const g   = new graphology.MultiGraph();
+    const pos = layout(data);
+
+    // container nodes — larger, accent border
+    data.containers.forEach(c => {
+      const id = 'c:' + c.addr;
+      const p  = pos[id] || { x: 0, y: 0 };
+      g.addNode(id, {
+        label:       c.name,
+        x: p.x, y: p.y,
+        size:        20,
+        color:       '#1f2937',
+        borderColor: '#388bfd',
+        kind:        'container',
+        raw:         c,
+      });
+    });
+
+    // agent nodes + thin membership edges
+    data.agents.forEach(a => {
+      const id = 'a:' + a.container_addr + ':' + a.aid;
+      const p  = pos[id] || { x: 0, y: -2 };
+      const sc = STATUS_COLORS[a.status] || '#8b949e';
+
+      g.addNode(id, {
+        label: a.aid,
+        x: p.x, y: p.y,
+        size:  13,
+        color: sc,
+        kind:  'agent',
+        raw:   a,
+      });
+
+      // membership edge
+      if (g.hasNode('c:' + a.container_addr)) {
+        g.addEdge('c:' + a.container_addr, id, {
+          color:  '#21262d',
+          size:   1,
+          type:   'line',
+          label:  '',
+          kind:   'member',
+        });
+      }
+    });
+
+    // declared connection edges
+    data.connections.forEach(c => {
+      const color = CONN_COLORS[c.conn_type] || '#8b949e';
+      const src   = 'a:' + c.source_addr + ':' + c.source_aid;
+      const tgt   = 'a:' + c.target_addr + ':' + c.target_aid;
+
+      if (!g.hasNode(src) || !g.hasNode(tgt)) return;
+
+      g.addEdge(src, tgt, {
+        color, size: 2.5,
+        type:  'arrow',
+        label: c.conn_type,
+        kind:  'connection',
+      });
+
+      if (c.direction === 'bi') {
+        g.addEdge(tgt, src, {
+          color, size: 2.5,
+          type:  'arrow',
+          label: '',
+          kind:  'connection',
+        });
+      }
+    });
+
+    return g;
+  }
+
+  // ── Renderer ─────────────────────────────────────────────────────────────────
+
+  function initSigma(g) {
+    if (sigma) { sigma.kill(); sigma = null; }
+
+    sigma = new Sigma(g, document.getElementById('sigma-canvas'), {
+      renderEdgeLabels:  true,
+      defaultEdgeType:   'arrow',
+      labelColor:        { color: '#c9d1d9' },
+      labelSize:         13,
+      labelWeight:       '600',
+      labelRenderedSizeThreshold: 6,
+      edgeLabelColor:    { color: '#8b949e' },
+      edgeLabelSize:     10,
+      defaultNodeColor:  '#21262d',
+      defaultEdgeColor:  '#30363d',
+      minCameraRatio:    0.05,
+      maxCameraRatio:    20,
+    });
+
+    // ── Tooltip ──────────────────────────────────────────────────────────────
+
+    const ttEl = document.getElementById('tooltip');
+
+    sigma.on('enterNode', ({ node }) => {
+      const d = g.getNodeAttributes(node);
+      const r = d.raw || {};
+      let html = '';
+
+      if (d.kind === 'container') {
+        html = `<div class="tt-title">📦 ${d.label}</div>
+                <div class="tt-row">addr <span>${r.addr || ''}</span></div>`;
+      } else {
+        const sc = STATUS_COLORS[r.status] || '#8b949e';
+        html = `<div class="tt-title">● ${d.label}</div>
+                <div class="tt-row">container <span>${r.container_addr || ''}</span></div>
+                <div class="tt-row">status <span style="color:${sc}">${r.status || 'unknown'}</span></div>`;
+      }
+
+      ttEl.innerHTML = html;
+      ttEl.style.display = 'block';
+    });
+
+    sigma.on('leaveNode', () => { ttEl.style.display = 'none'; });
+
+    sigma.getMouseCaptor().on('mousemove', e => {
+      ttEl.style.left = (e.x + 16) + 'px';
+      ttEl.style.top  = (e.y + 16) + 'px';
+    });
+
+    fitView();
+  }
+
+  // ── Fit / zoom ────────────────────────────────────────────────────────────────
+
+  function fitView() {
+    if (!sigma || !graph || !graph.order) return;
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    graph.forEachNode((_, { x, y }) => {
+      if (x < minX) minX = x; if (y < minY) minY = y;
+      if (x > maxX) maxX = x; if (y > maxY) maxY = y;
+    });
+
+    const cx     = (minX + maxX) / 2;
+    const cy     = (minY + maxY) / 2;
+    const rangeX = Math.max(maxX - minX, 1);
+    const rangeY = Math.max(maxY - minY, 1);
+
+    const wrap  = document.getElementById('sigma-wrap');
+    const wW    = wrap.clientWidth;
+    const wH    = wrap.clientHeight;
+
+    // sigma camera ratio: graph-units per pixel. Lower = more zoomed in.
+    const ratio = Math.max(rangeX / wW, rangeY / wH) * 1.5;
+
+    sigma.getCamera().animate(
+      { x: cx, y: cy, ratio, angle: 0 },
+      { duration: 400 }
+    );
+  }
+
+  // ── Controls ──────────────────────────────────────────────────────────────────
+
+  document.getElementById('btn-fit').addEventListener('click', fitView);
+  document.getElementById('btn-zoomin').addEventListener('click', () => {
+    sigma && sigma.getCamera().animatedZoom({ factor: 1.5, duration: 200 });
+  });
+  document.getElementById('btn-zoomout').addEventListener('click', () => {
+    sigma && sigma.getCamera().animatedUnzoom({ factor: 1.5, duration: 200 });
+  });
+
+  document.addEventListener('keydown', e => {
+    if (!sigma) return;
+    if (e.key === 'f' || e.key === 'F') fitView();
+    if (e.key === '+' || e.key === '=') sigma.getCamera().animatedZoom({ factor: 1.5, duration: 200 });
+    if (e.key === '-')                   sigma.getCamera().animatedUnzoom({ factor: 1.5, duration: 200 });
+  });
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+
+  function render(data) {
+    document.getElementById('n-containers').textContent = data.containers.length;
+    document.getElementById('n-agents').textContent     = data.agents.length;
+    document.getElementById('n-connections').textContent = data.connections.length;
+
+    const hasData = data.containers.length > 0 || data.agents.length > 0;
+    document.getElementById('empty').classList.toggle('hidden', hasData);
+
+    graph = buildGraph(data);
+    initSigma(graph);
+  }
+
+  // ── WebSocket ─────────────────────────────────────────────────────────────────
+
+  const dot  = document.getElementById('dot');
+  const stxt = document.getElementById('status-text');
+
+  function connect() {
+    const ws = new WebSocket('ws://' + location.host + '/ws');
+
+    ws.onopen = () => {
+      dot.className = 'live';
+      stxt.textContent = 'live';
+    };
+    ws.onclose = () => {
+      dot.className = 'dead';
+      stxt.textContent = 'reconnecting…';
+      setTimeout(connect, 2000);
+    };
+    ws.onerror = () => { dot.className = 'dead'; };
+    ws.onmessage = e => render(JSON.parse(e.data));
+  }
+
+  connect();
+</script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dependencies = [
 fastjson = [
     "msgspec>=0.18.6"
 ]
+ui = [
+    "fastapi>=0.100",
+    "uvicorn>=0.20",
+]
 test = [
     "pytest",
     "pytest-cov",

--- a/test_ui_scenario.py
+++ b/test_ui_scenario.py
@@ -11,7 +11,6 @@ import sys
 sys.path.insert(0, "/home/b2k/Desktop/Season2/mango")
 
 from mango import Agent, create_tcp_container, activate, addr
-from mango.ui import TopologyRegistry
 
 
 class SensorAgent(Agent):
@@ -53,27 +52,21 @@ async def main():
     container_a.register(processor, suggested_aid="processor")
     container_b.register(monitor,   suggested_aid="monitor")
 
-    # set up registry — must happen after agents are registered
-    # so the backfill in register() picks them up
-    registry = TopologyRegistry()
-    registry.register(container_a)
-    registry.register(container_b)
+    # ui=True spins up the topology UI server and registers every container
+    # passed to activate() with it once they're running
+    async with activate(container_a, container_b, ui=True) as (container_a, container_b):
+        # any container's `.registry` is the same shared TopologyRegistry instance
+        container_a.registry.add_connection(sensor.addr,    processor.addr, conn_type="internal", direction="uni")
+        container_a.registry.add_connection(processor.addr, monitor.addr,   conn_type="tcp",      direction="uni")
+        container_a.registry.add_connection(monitor.addr,   sensor.addr,    conn_type="tcp",      direction="bi")
 
-    # declare connections
-    registry.add_connection(sensor.addr,    processor.addr, conn_type="internal", direction="uni")
-    registry.add_connection(processor.addr, monitor.addr,   conn_type="tcp",      direction="uni")
-    registry.add_connection(monitor.addr,   sensor.addr,    conn_type="tcp",      direction="bi")
-
-    async with activate(container_a, container_b):
-        # start UI server inside the running loop
-        await registry.start_server(host="localhost", port=8000)
         print("Topology UI: http://localhost:8000")
         print("Press Ctrl+C to stop.\n")
 
         # run health checks every 3 seconds
         while True:
             await asyncio.sleep(3)
-            await registry.check_health()
+            await container_a.registry.check_health()
 
 
 if __name__ == "__main__":

--- a/test_ui_scenario.py
+++ b/test_ui_scenario.py
@@ -1,0 +1,83 @@
+"""
+Simple scenario to test the TopologyRegistry UI.
+
+Two containers, three agents with declared connections.
+Open http://localhost:8000 after running this script.
+Press Ctrl+C to stop.
+"""
+
+import asyncio
+import sys
+sys.path.insert(0, "/home/b2k/Desktop/Season2/mango")
+
+from mango import Agent, create_tcp_container, activate, addr
+from mango.ui import TopologyRegistry
+
+
+class SensorAgent(Agent):
+    def handle_message(self, content, meta):
+        print(f"[SensorAgent] received: {content}")
+
+    async def health_check(self):
+        return "active"
+
+
+class ProcessorAgent(Agent):
+    def handle_message(self, content, meta):
+        print(f"[ProcessorAgent] received: {content}")
+
+    async def health_check(self):
+        return "active"
+
+
+class MonitorAgent(Agent):
+    def handle_message(self, content, meta):
+        print(f"[MonitorAgent] received: {content}")
+
+    async def health_check(self):
+        return "idle"
+
+
+async def main():
+    # two containers on different ports
+    container_a = create_tcp_container(addr=("127.0.0.1", 5555))
+    container_b = create_tcp_container(addr=("127.0.0.1", 5556))
+
+    # create agents
+    sensor    = SensorAgent()
+    processor = ProcessorAgent()
+    monitor   = MonitorAgent(visible=True)
+
+    # register agents to containers
+    container_a.register(sensor,    suggested_aid="sensor")
+    container_a.register(processor, suggested_aid="processor")
+    container_b.register(monitor,   suggested_aid="monitor")
+
+    # set up registry — must happen after agents are registered
+    # so the backfill in register() picks them up
+    registry = TopologyRegistry()
+    registry.register(container_a)
+    registry.register(container_b)
+
+    # declare connections
+    registry.add_connection(sensor.addr,    processor.addr, conn_type="internal", direction="uni")
+    registry.add_connection(processor.addr, monitor.addr,   conn_type="tcp",      direction="uni")
+    registry.add_connection(monitor.addr,   sensor.addr,    conn_type="tcp",      direction="bi")
+
+    async with activate(container_a, container_b):
+        # start UI server inside the running loop
+        await registry.start_server(host="localhost", port=8000)
+        print("Topology UI: http://localhost:8000")
+        print("Press Ctrl+C to stop.\n")
+
+        # run health checks every 3 seconds
+        while True:
+            await asyncio.sleep(3)
+            await registry.check_health()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nStopped.")

--- a/tests/integration_tests/test_ui_registry_mp.py
+++ b/tests/integration_tests/test_ui_registry_mp.py
@@ -1,0 +1,26 @@
+import pytest
+
+from mango import Agent, activate, create_tcp_container
+from mango.ui import TopologyRegistry
+
+
+@pytest.mark.asyncio
+async def test_registry_backfills_and_clears_subprocess_agents():
+    c = create_tcp_container(addr=("127.0.0.1", 15790))
+    await c.as_agent_process(
+        agent_creator=lambda container: container.register(
+            Agent(), suggested_aid="sp_agent"
+        )
+    )
+    c.register(Agent(), suggested_aid="main_agent")
+
+    registry = TopologyRegistry()
+
+    async with activate(c) as c:
+        registry.register(c)
+        assert f"{c.addr}:sp_agent" in registry._agents
+        assert f"{c.addr}:main_agent" in registry._agents
+
+    # container shutdown should deregister subprocess-resident agents too
+    assert registry._agents == {}
+    assert registry._containers == {}

--- a/tests/manual/ui_topology_demo.py
+++ b/tests/manual/ui_topology_demo.py
@@ -1,16 +1,15 @@
 """
-Simple scenario to test the TopologyRegistry UI.
+Manual demo for the topology UI — not part of the automated test suite
+(pytest won't collect this; filename doesn't match test_*.py).
 
 Two containers, three agents with declared connections.
-Open http://localhost:8000 after running this script.
-Press Ctrl+C to stop.
+Run with: python -m tests.manual.ui_topology_demo
+Then open http://localhost:8000 — Ctrl+C to stop.
 """
 
 import asyncio
-import sys
-sys.path.insert(0, "/home/b2k/Desktop/Season2/mango")
 
-from mango import Agent, create_tcp_container, activate, addr
+from mango import Agent, activate, create_tcp_container
 
 
 class SensorAgent(Agent):
@@ -43,22 +42,31 @@ async def main():
     container_b = create_tcp_container(addr=("127.0.0.1", 5556))
 
     # create agents
-    sensor    = SensorAgent()
+    sensor = SensorAgent()
     processor = ProcessorAgent()
-    monitor   = MonitorAgent(visible=True)
+    monitor = MonitorAgent(visible=True)
 
     # register agents to containers
-    container_a.register(sensor,    suggested_aid="sensor")
+    container_a.register(sensor, suggested_aid="sensor")
     container_a.register(processor, suggested_aid="processor")
-    container_b.register(monitor,   suggested_aid="monitor")
+    container_b.register(monitor, suggested_aid="monitor")
 
-    # ui=True spins up the topology UI server and registers every container
+    # ui=True starts the topology UI server and registers every container
     # passed to activate() with it once they're running
-    async with activate(container_a, container_b, ui=True) as (container_a, container_b):
+    async with activate(container_a, container_b, ui=True) as (
+        container_a,
+        container_b,
+    ):
         # any container's `.registry` is the same shared TopologyRegistry instance
-        container_a.registry.add_connection(sensor.addr,    processor.addr, conn_type="internal", direction="uni")
-        container_a.registry.add_connection(processor.addr, monitor.addr,   conn_type="tcp",      direction="uni")
-        container_a.registry.add_connection(monitor.addr,   sensor.addr,    conn_type="tcp",      direction="bi")
+        container_a.registry.add_connection(
+            sensor.addr, processor.addr, conn_type="internal", direction="uni"
+        )
+        container_a.registry.add_connection(
+            processor.addr, monitor.addr, conn_type="tcp", direction="uni"
+        )
+        container_a.registry.add_connection(
+            monitor.addr, sensor.addr, conn_type="tcp", direction="bi"
+        )
 
         print("Topology UI: http://localhost:8000")
         print("Press Ctrl+C to stop.\n")

--- a/tests/unit_tests/express/test_api.py
+++ b/tests/unit_tests/express/test_api.py
@@ -153,6 +153,27 @@ async def test_run_api_style_agent_with_aid_mqtt():
 
 
 @pytest.mark.asyncio
+async def test_activate_with_ui():
+    pytest.importorskip("fastapi")
+    pytest.importorskip("uvicorn")
+
+    c = create_tcp_container(addr=("127.0.0.1", 15791))
+
+    async with activate(c, ui=True, ui_port=15792) as c:
+        c.register(MyAgent(), suggested_aid="ui_agent")
+        registry = c.registry
+        assert registry is not None
+        assert f"{c.addr}:ui_agent" in registry._agents
+        assert registry._uvicorn_server is not None
+
+    # exiting the context must stop the UI server and clear the topology
+    assert registry._uvicorn_server is None
+    assert registry._server_task is None
+    assert registry._agents == {}
+    assert registry._containers == {}
+
+
+@pytest.mark.asyncio
 async def test_deactivate_suspendable():
     container = create_tcp_container("127.0.0.1:5555")
     ping_pong_agent = agent_composed_of(PingPongRole(), register_in=container)

--- a/tests/unit_tests/ui/test_registry.py
+++ b/tests/unit_tests/ui/test_registry.py
@@ -1,0 +1,90 @@
+import pytest
+
+from mango import Agent, activate, create_tcp_container
+from mango.ui import TopologyRegistry
+
+
+@pytest.mark.asyncio
+async def test_register_backfills_visible_agents():
+    c = create_tcp_container(addr=("127.0.0.1", 15780))
+    c.register(Agent(), suggested_aid="visible_one")
+
+    registry = TopologyRegistry()
+    registry.register(c)
+
+    assert f"{c.addr}:visible_one" in registry._agents
+
+
+@pytest.mark.asyncio
+async def test_register_skips_invisible_agents():
+    c = create_tcp_container(addr=("127.0.0.1", 15781))
+    c.register(Agent(visible=False), suggested_aid="hidden_one")
+
+    registry = TopologyRegistry()
+    registry.register(c)
+
+    assert f"{c.addr}:hidden_one" not in registry._agents
+
+
+@pytest.mark.asyncio
+async def test_live_register_and_deregister_agent():
+    c = create_tcp_container(addr=("127.0.0.1", 15782))
+    registry = TopologyRegistry()
+    registry.register(c)
+
+    async with activate(c) as c:
+        agent = c.register(Agent(), suggested_aid="live_agent")
+        assert f"{c.addr}:live_agent" in registry._agents
+
+        await agent.shutdown()
+        assert f"{c.addr}:live_agent" not in registry._agents
+
+
+@pytest.mark.asyncio
+async def test_container_shutdown_clears_registry():
+    c = create_tcp_container(addr=("127.0.0.1", 15783))
+    registry = TopologyRegistry()
+
+    async with activate(c) as c:
+        registry.register(c)
+        c.register(Agent(), suggested_aid="agent_one")
+        assert registry._agents
+        assert registry._containers
+
+    assert registry._agents == {}
+    assert registry._containers == {}
+
+
+@pytest.mark.asyncio
+async def test_add_connection_snapshot():
+    c1 = create_tcp_container(addr=("127.0.0.1", 15784))
+    c2 = create_tcp_container(addr=("127.0.0.1", 15785))
+    registry = TopologyRegistry()
+    registry.register(c1)
+    registry.register(c2)
+
+    a1 = c1.register(Agent(), suggested_aid="a1")
+    a2 = c2.register(Agent(), suggested_aid="a2")
+
+    registry.add_connection(a1.addr, a2.addr, conn_type="tcp", direction="uni")
+
+    snapshot = registry._snapshot()
+    assert len(snapshot["connections"]) == 1
+    assert snapshot["connections"][0]["source_aid"] == "a1"
+    assert snapshot["connections"][0]["target_aid"] == "a2"
+
+
+@pytest.mark.asyncio
+async def test_check_health_uses_agent_health_check():
+    class HealthyAgent(Agent):
+        async def health_check(self):
+            return "great"
+
+    c = create_tcp_container(addr=("127.0.0.1", 15786))
+    registry = TopologyRegistry()
+    registry.register(c)
+    c.register(HealthyAgent(), suggested_aid="healthy")
+
+    await registry.check_health()
+
+    assert registry._agents[f"{c.addr}:healthy"].status == "great"


### PR DESCRIPTION
## Architecture

| Component | Location | Responsibility |
|-----------|----------|----------------|
| `TopologyRegistry` | `mango/ui/registry.py` | Tracks containers, agents, connections; broadcasts updates over WebSocket |
| FastAPI app | `mango/ui/server.py` | Serves `GET /` (HTML) and `GET /ws` (WebSocket) |
| Frontend | `mango/ui/static/index.html` | Cytoscape-based graph; connects to the WebSocket and re-renders on every message |

`Container` hooks (`_registry`) call `on_agent_registered` / `on_agent_deregistered` / `on_container_removed` on the registry as agents come and go. Every topology change triggers a full-state broadcast to all connected browser tabs.

## Known limitations

- **Subprocess agents created after `activate()`:** agents started via `container.as_agent_process()` *before* `activate(ui=True)` is called are backfilled into the registry at registration time. Agents spawned into subprocesses *after* the `activate()` block is already running will not appear in the dashboard. Extending the IPC wire protocol to carry live agent-identity events would be required to lift this restriction.
- **No authentication:** the dashboard is intended for local development. Do not bind `ui_host` to a public interface in production without adding auth.

## Running the demo

```bash
python -m tests.manual.ui_topology_demo
```

Then open `http://localhost:8000`. Press `Ctrl+C` to stop.

---

## Changes

Adds a live web dashboard (`mango/ui/`) that visualises running agents and containers as an interactive graph. Containers and agents opt in via `activate(ui=True)` and the `visible` flag respectively. The frontend uses Cytoscape.js over a WebSocket connection so the graph updates in real time without a page refresh. Proper teardown is wired into `Container.shutdown()` and `ContainerActivationManager.__aexit__` so the server stops cleanly and ghost entries never accumulate across restarts.
